### PR TITLE
Implement muting monit securely

### DIFF
--- a/modules/monit/manifests/init.pp
+++ b/modules/monit/manifests/init.pp
@@ -68,6 +68,15 @@ class monit ($emailTo = 'root@localhost', $emailFrom = 'root@localhost', $allowe
   }
   ->
 
+  file { '/usr/local/bin/monit-silent':
+    ensure => file,
+    content => template('monit/bin/monit-silent.sh'),
+    group => '0',
+    owner => '0',
+    mode => '0755',
+  }
+  ->
+
   file { '/etc/monit/monitrc':
     content => template('monit/monitrc'),
     ensure => file,

--- a/modules/monit/spec/alerting/spec.rb
+++ b/modules/monit/spec/alerting/spec.rb
@@ -20,12 +20,12 @@ describe command('monit-alert default') do
   it { should return_exit_status 0 }
 end
 
-describe file('/etc/monit/conf.d/alert') do
-  its(:content) { should match /set alert/ }
-end
-
 describe command('monit-silent foo bar') do
   it { should return_exit_status 1 }
+end
+
+describe file('/etc/monit/conf.d/alert') do
+  its(:content) { should match /set alert/ }
 end
 
 describe command('echo "" >/var/spool/mail/vagrant') do
@@ -40,7 +40,6 @@ describe command('echo q | mail -u vagrant | grep monit | wc -l ') do
   it { should return_exit_status 0 }
   its(:stdout) { should match /1\n/ }
 end
-
 
 describe process('monit') do
   it { should be_running }

--- a/modules/monit/spec/alerting/spec.rb
+++ b/modules/monit/spec/alerting/spec.rb
@@ -24,6 +24,20 @@ describe file('/etc/monit/conf.d/alert') do
   its(:content) { should match /set alert/ }
 end
 
+describe command('monit-silent foo bar') do
+  it { should return_exit_status 1 }
+end
+
+describe command('monit-silent unmonitor root') do
+  it { should return_exit_status 0 }
+end
+
+describe command('echo q | mail -u vagrant | grep monit | wc -l ') do
+  it { should return_exit_status 0 }
+  its(:stdout) { should match /1\n/ }
+end
+
+
 describe process('monit') do
   it { should be_running }
 end

--- a/modules/monit/spec/alerting/spec.rb
+++ b/modules/monit/spec/alerting/spec.rb
@@ -28,6 +28,10 @@ describe command('monit-silent foo bar') do
   it { should return_exit_status 1 }
 end
 
+describe command('echo "" >/var/spool/mail/vagrant') do
+  it { should return_exit_status 0 }
+end
+
 describe command('monit-silent unmonitor root') do
   it { should return_exit_status 0 }
 end

--- a/modules/monit/templates/bin/monit-silent.sh
+++ b/modules/monit/templates/bin/monit-silent.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+trap 'monit-alert default' ERR
+
+monit-alert none
+monit $1 $2
+monit-alert default

--- a/modules/monit/templates/bin/monit-silent.sh
+++ b/modules/monit/templates/bin/monit-silent.sh
@@ -3,5 +3,5 @@
 trap 'monit-alert default' ERR
 
 monit-alert none
-monit $1 $2
+monit $@
 monit-alert default


### PR DESCRIPTION
Goal: Have `monit unmonitor` and `monit monitor` events not sending alert mails

Idea: `monit-silent <action>` - executes `monit-alert none && monit <action> && monit-alert default` or similar

As discussed in https://github.com/cargomedia/puppet-packages/pull/648, https://github.com/cargomedia/puppet-packages/pull/554#issuecomment-47324762 and requested in https://bitbucket.org/tildeslash/monit/issue/66/add-alert-silencing-option