### PR TITLE
php segfaults leads to re-installation of extensions

### DIFF
--- a/modules/composer/manifests/init.pp
+++ b/modules/composer/manifests/init.pp
@@ -9,7 +9,7 @@ class composer($version = '1.0.0-alpha9') {
   exec {"curl ${phar}":
     command => "curl -sL http://getcomposer.org/download/${version}/composer.phar > ${phar}",
     path => ['/usr/local/bin', '/usr/bin', '/bin'],
-    unless => "${binary} --version | grep -w '${version}'",
+    unless => "${binary} --version | grep -w '${version}' || [ ${PIPESTATUS[0]} == 139 ]",
     require => [File[$binary], File[$config]],
   }
 

--- a/modules/php5/manifests/extension/apc.pp
+++ b/modules/php5/manifests/extension/apc.pp
@@ -12,7 +12,7 @@ class php5::extension::apc (
 
   helper::script {'install php5::apc':
     content => template("${module_name}/extension/apc/install.sh"),
-    unless => "php --re apc | grep 'apc version' | grep ' ${version} '",
+    unless => "php --re apc | grep 'apc version' | grep ' ${version} ' || [ ${PIPESTATUS[0]} == 139 ]",
     require => Class['php5'],
   }
   ->

--- a/modules/php5/manifests/extension/apcu.pp
+++ b/modules/php5/manifests/extension/apcu.pp
@@ -11,7 +11,7 @@ class php5::extension::apcu (
 
   helper::script {'install php5::apcu':
     content => template("${module_name}/extension/apcu/install.sh"),
-    unless => "php --re apcu | grep 'apcu version' | grep ' ${version} '",
+    unless => "php --re apcu | grep 'apcu version' | grep ' ${version} ' || [ ${PIPESTATUS[0]} == 139 ]",
     require => Class['php5'],
   }
   ->

--- a/modules/php5/manifests/extension/gearman.pp
+++ b/modules/php5/manifests/extension/gearman.pp
@@ -8,7 +8,7 @@ class php5::extension::gearman (
 
   helper::script {'install php5::extension::gearman':
     content => template("${module_name}/extension/gearman/install.sh"),
-    unless => "php --re gearman | grep -w 'gearman version ${version}'",
+    unless => "php --re gearman | grep -w 'gearman version ${version}' || [ ${PIPESTATUS[0]} == 139 ]",
     require => Class['php5'],
   }
   ->

--- a/modules/php5/manifests/extension/imagick.pp
+++ b/modules/php5/manifests/extension/imagick.pp
@@ -12,7 +12,7 @@ class php5::extension::imagick (
 
   helper::script {'install php5::extension::imagick':
     content => template("${module_name}/extension/imagick/install.sh"),
-    unless => "php --re imagick | grep -w 'imagick version ${version}'",
+    unless => "php --re imagick | grep -w 'imagick version ${version}' || [ ${PIPESTATUS[0]} == 139 ]",
     require => Class['php5'],
   }
   ->

--- a/modules/php5/manifests/extension/mongo.pp
+++ b/modules/php5/manifests/extension/mongo.pp
@@ -5,7 +5,7 @@ class php5::extension::mongo($version = '1.5.6') {
 
   helper::script {'install php5::mongo':
     content => template("${module_name}/extension/mongo/install.sh"),
-    unless => "php --re mongo | grep 'mongo version' | grep ' ${version} '",
+    unless => "php --re mongo | grep 'mongo version' | grep ' ${version} ' || [ ${PIPESTATUS[0]} == 139 ]",
   }
   ->
 

--- a/modules/php5/manifests/extension/opcache.pp
+++ b/modules/php5/manifests/extension/opcache.pp
@@ -15,7 +15,7 @@ class php5::extension::opcache (
 
   helper::script {'install php5::extension::opcache':
     content => template("${module_name}/extension/opcache/install.sh"),
-    unless => "php --re 'Zend OPcache' | grep 'Zend OPcache version ${version_output} '",
+    unless => "php --re 'Zend OPcache' | grep 'Zend OPcache version ${version_output} ' || [ ${PIPESTATUS[0]} == 139 ]",
     require => Class['php5'],
   }
   ->

--- a/modules/php5/manifests/extension/redis.pp
+++ b/modules/php5/manifests/extension/redis.pp
@@ -6,7 +6,7 @@ class php5::extension::redis {
 
   helper::script {'install php5-redis':
     content => template("${module_name}/extension/redis/install.sh"),
-    unless => "php --ri redis | grep '^Redis Version => ${version}$'",
+    unless => "php --ri redis | grep '^Redis Version => ${version}$' || [ ${PIPESTATUS[0]} == 139 ]",
     require => Class['php5'],
   }
   ->

--- a/modules/php5/manifests/extension/runkit.pp
+++ b/modules/php5/manifests/extension/runkit.pp
@@ -9,7 +9,7 @@ class php5::extension::runkit (
 
   helper::script {'install php5::extension::runkit':
     content => template("${module_name}/extension/runkit/install.sh"),
-    unless => "php --re runkit | grep -w 'runkit version ${version}'",
+    unless => "php --re runkit | grep -w 'runkit version ${version}' || [ ${PIPESTATUS[0]} == 139 ]",
     require => Class['php5', 'git'],
   }
   ->

--- a/modules/php5/manifests/extension/stats.pp
+++ b/modules/php5/manifests/extension/stats.pp
@@ -7,7 +7,7 @@ class php5::extension::stats (
 
   helper::script {'install php5::extension::stats':
     content => template("${module_name}/extension/stats/install.sh"),
-    unless => "php --re stats | grep -w 'stats version ${version}'",
+    unless => "php --re stats | grep -w 'stats version ${version}' || [ ${PIPESTATUS[0]} == 139 ]",
     require => Class['php5'],
   }
   ->

--- a/modules/php5/manifests/extension/svm.pp
+++ b/modules/php5/manifests/extension/svm.pp
@@ -13,7 +13,7 @@ class php5::extension::svm (
 
   helper::script {'install php5::extension::svm':
     content => template("${module_name}/extension/svm/install.sh"),
-    unless => "php --re svm | grep -w 'svm version ${version_output}'",
+    unless => "php --re svm | grep -w 'svm version ${version_output}' || [ ${PIPESTATUS[0]} == 139 ]",
     require => Class['php5'],
   }
   ->


### PR DESCRIPTION
I observed this behaviour on `www5` by chance:

syslog:
```
2014-12-23T09:54:53.602483+00:00 www5 kernel: [6467088.885649] php[12797]: segfault at ffffffffffffffff ip 00007fc60dfd0828 sp 00007fff6cfc5f38 error 7 in libpthread-2.13.so[7fc60dfc6000+17000]
2014-12-23T09:55:11.025553+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Mongo/Helper::Script[install php5::mongo]/Exec[exec install php5::mongo]/returns) executed successfully
2014-12-23T09:55:11.122467+00:00 www5 kernel: [6467106.401101] php[16293]: segfault at ffffffffffffffff ip 00007f61147f8828 sp 00007fff70fd5908 error 7 in libpthread-2.13.so[7f61147ee000+17000]
2014-12-23T09:55:15.516976+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Gearman/Helper::Script[install php5::extension::gearman]/Exec[exec install php5::extension::gearman]/returns) executed successfully
2014-12-23T09:55:15.614473+00:00 www5 kernel: [6467110.894148] php[18409]: segfault at ffffffffffffffff ip 00007f2290108828 sp 00007fffb280fe78 error 7 in libpthread-2.13.so[7f22900fe000+17000]
2014-12-23T09:55:24.825617+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Svm/Helper::Script[install php5::extension::svm]/Exec[exec install php5::extension::svm]/returns) executed successfully
2014-12-23T09:55:24.912158+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Mongo/Helper::Script[install php5::mongo]/Exec[cleanup install php5::mongo]) Triggered 'refresh' from 1 events
2014-12-23T09:55:24.987469+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Svm/Helper::Script[install php5::extension::svm]/Exec[cleanup install php5::extension::svm]) Triggered 'refresh' from 1 events
2014-12-23T09:55:25.082467+00:00 www5 kernel: [6467120.358203] php[20532]: segfault at ffffffffffffffff ip 00007f3a43440828 sp 00007fff148d4ff8 error 7 in libpthread-2.13.so[7f3a43436000+17000]
2014-12-23T09:55:31.711311+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Runkit/Helper::Script[install php5::extension::runkit]/Exec[exec install php5::extension::runkit]/returns) executed successfully
2014-12-23T09:55:31.786589+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Runkit/Helper::Script[install php5::extension::runkit]/Exec[cleanup install php5::extension::runkit]) Triggered 'refresh' from 1 events
2014-12-23T09:55:31.878473+00:00 www5 kernel: [6467127.152949] php[22733]: segfault at ffffffffffffffff ip 00007f3657538828 sp 00007fffa08bd5a8 error 7 in libpthread-2.13.so[7f365752e000+17000]
2014-12-23T09:55:44.783307+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Opcache/Helper::Script[install php5::extension::opcache]/Exec[exec install php5::extension::opcache]/returns) executed successfully
2014-12-23T09:55:44.867647+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Opcache/Helper::Script[install php5::extension::opcache]/Exec[cleanup install php5::extension::opcache]) Triggered 'refresh' from 1 events
2014-12-23T09:55:44.962468+00:00 www5 kernel: [6467140.231713] php[25168]: segfault at ffffffffffffffff ip 00007f10c6d61828 sp 00007fff60e585a8 error 7 in libpthread-2.13.so[7f10c6d57000+17000]
2014-12-23T09:55:53.804294+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Imagick/Helper::Script[install php5::extension::imagick]/Exec[exec install php5::extension::imagick]/returns) executed successfully
2014-12-23T09:55:53.877361+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Imagick/Helper::Script[install php5::extension::imagick]/Exec[cleanup install php5::extension::imagick]) Triggered 'refresh' from 1 events
2014-12-23T09:55:53.970466+00:00 www5 kernel: [6467149.239441] php[27833]: segfault at ffffffffffffffff ip 00007faaf7914828 sp 00007fffb4797928 error 7 in libpthread-2.13.so[7faaf790a000+17000]
2014-12-23T09:55:56.008149+00:00 www5 puppet-agent[11953]: (/Stage[main]/Composer/Exec[curl /usr/local/lib/composer.phar]/returns) executed successfully
2014-12-23T09:55:56.106466+00:00 www5 kernel: [6467151.373895] php[27845]: segfault at ffffffffffffffff ip 00007f45d64ba828 sp 00007fff2298fb28 error 7 in libpthread-2.13.so[7f45d64b0000+17000]
2014-12-23T09:56:02.424003+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Stats/Helper::Script[install php5::extension::stats]/Exec[exec install php5::extension::stats]/returns) executed successfully
2014-12-23T09:56:02.499486+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Stats/Helper::Script[install php5::extension::stats]/Exec[cleanup install php5::extension::stats]) Triggered 'refresh' from 1 events
2014-12-23T09:56:02.598464+00:00 www5 kernel: [6467157.865298] php[30043]: segfault at ffffffffffffffff ip 00007f57afa93828 sp 00007fffa38d5578 error 7 in libpthread-2.13.so[7f57afa89000+17000]
2014-12-23T09:56:16.673774+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Redis/Helper::Script[install php5-redis]/Exec[exec install php5-redis]/returns) executed successfully
2014-12-23T09:56:16.746685+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Redis/Helper::Script[install php5-redis]/Exec[cleanup install php5-redis]) Triggered 'refresh' from 1 events
2014-12-23T09:56:16.842468+00:00 www5 kernel: [6467172.105741] php[32270]: segfault at ffffffffffffffff ip 00007fe91079f828 sp 00007ffff6b1c528 error 7 in libpthread-2.13.so[7fe910795000+17000]
2014-12-23T09:56:23.584930+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Apcu/Helper::Script[install php5::apcu]/Exec[exec install php5::apcu]/returns) executed successfully
2014-12-23T09:56:23.657868+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Apcu/Helper::Script[install php5::apcu]/Exec[cleanup install php5::apcu]) Triggered 'refresh' from 1 events
2014-12-23T09:56:23.830244+00:00 www5 puppet-agent[11953]: (/Stage[main]/Php5::Extension::Gearman/Helper::Script[install php5::extension::gearman]/Exec[cleanup install php5::extension::gearman]) Triggered 'refresh' from 1 events
```

The server was having a high memory pressure due to yet unknown causes. If the puppet modules involved base the decision about installing or not on invoking e.g. `unless => "php --re imagick | grep -w 'imagick version ${version}'",` and `php` exits with a segfault, puppet will try to install the extension **leading to even more pressure on the machine**

A possible fix is to add a check about `php` segfaulting versus otherwise exiting with an ordinary failure

@kris-lab agree?