### PR TITLE
Wowza keeps reinstalling after machine reboot

### DIFF
--- a/modules/puppet/manifests/common.pp
+++ b/modules/puppet/manifests/common.pp
@@ -4,7 +4,7 @@ class puppet::common(
 
   helper::script {'install puppet apt sources':
     content => template("${module_name}/install-apt-sources.sh"),
-    unless => "dpkg-query -f '\${Status} \${Version}\n' -W puppetlabs-release | grep -q 'ok installed ${version}'",
+    unless => "dpkg-query -f '\${Status}\n' -W puppetlabs-release | grep -q 'ok installed'",
   }
 
   file {'/etc/puppet':

--- a/modules/puppet/manifests/common.pp
+++ b/modules/puppet/manifests/common.pp
@@ -4,7 +4,7 @@ class puppet::common(
 
   helper::script {'install puppet apt sources':
     content => template("${module_name}/install-apt-sources.sh"),
-    unless => "dpkg-query -f '\${Status}\n' -W puppetlabs-release | grep -q 'ok installed'",
+    unless => 'dpkg-query -f \'${Status}\n\' -W puppetlabs-release | grep -q \'ok installed\'',
   }
 
   file {'/etc/puppet':

--- a/modules/puppet/manifests/common.pp
+++ b/modules/puppet/manifests/common.pp
@@ -4,7 +4,7 @@ class puppet::common(
 
   helper::script {'install puppet apt sources':
     content => template("${module_name}/install-apt-sources.sh"),
-    unless => 'dpkg-query -f \'${Status}\n\' -W puppetlabs-release | grep -q \'ok installed\'',
+    unless => "dpkg-query -f '\${Status}\n' -W puppetlabs-release | grep -q 'ok installed'",
   }
 
   file {'/etc/puppet':

--- a/modules/puppet/manifests/common.pp
+++ b/modules/puppet/manifests/common.pp
@@ -4,7 +4,7 @@ class puppet::common(
 
   helper::script {'install puppet apt sources':
     content => template("${module_name}/install-apt-sources.sh"),
-    unless => "dpkg-query -f '\${Status} \${Version}\n' -W puppetlabs-release | grep -q 'ok installed ${Version}'",
+    unless => "dpkg-query -f '\${Status} \${Version}\n' -W puppetlabs-release | grep -q 'ok installed ${version}'",
   }
 
   file {'/etc/puppet':

--- a/modules/puppet/manifests/common.pp
+++ b/modules/puppet/manifests/common.pp
@@ -4,7 +4,7 @@ class puppet::common(
 
   helper::script {'install puppet apt sources':
     content => template("${module_name}/install-apt-sources.sh"),
-    unless => "dpkg -l puppetlabs-release | grep '^ii '",
+    unless => "dpkg-query -f '\${Status} \${Version}\n' -W puppetlabs-release | grep -q 'ok installed ${Version}'",
   }
 
   file {'/etc/puppet':

--- a/modules/wowza/manifests/init.pp
+++ b/modules/wowza/manifests/init.pp
@@ -16,7 +16,7 @@ class wowza (
 
   helper::script {'install wowza':
     content => template("${module_name}/install.sh"),
-    unless => "dpkg -l | grep -q '^ii.* wowzastreamingengine-${version}'",
+    unless => "dpkg -l | grep -q '^ii.*${version}.*Wowza Streaming Engine'",
     timeout => 900,
     require => User['wowza'],
   }

--- a/modules/wowza/manifests/init.pp
+++ b/modules/wowza/manifests/init.pp
@@ -16,7 +16,7 @@ class wowza (
 
   helper::script {'install wowza':
     content => template("${module_name}/install.sh"),
-    unless => "dpkg-query -f '\${Status} \${Version}\n' -W wowzastreamingengine-${Version} | grep -q 'ok installed ${Version}'",
+    unless => "dpkg-query -f '\${Status} \${Version}\n' -W wowzastreamingengine-${version} | grep -q 'ok installed ${version}'",
     timeout => 900,
     require => User['wowza'],
   }

--- a/modules/wowza/manifests/init.pp
+++ b/modules/wowza/manifests/init.pp
@@ -16,7 +16,7 @@ class wowza (
 
   helper::script {'install wowza':
     content => template("${module_name}/install.sh"),
-    unless => "dpkg -l | grep -q '^ii.*${version}.*Wowza Streaming Engine'",
+    unless => "dpkg-query -f '\${Status} \${Version}\n' -W wowzastreamingengine-${Version} | grep -q 'ok installed ${Version}'",
     timeout => 900,
     require => User['wowza'],
   }


### PR DESCRIPTION
Follow-up of #667 

Happens after rebooting a machine.

Excerpt from `syslog` after booting:

```
2015-01-07T07:32:12.295620+00:00 wowza2 puppet-agent[3538]: Reopening log files
2015-01-07T07:32:12.421481+00:00 wowza2 puppet-agent[3538]: Starting Puppet client version 3.7.3
2015-01-07T07:32:18.502455+00:00 wowza2 kernel: [   23.858911] bond0: no IPv6 routers present
2015-01-07T07:32:19.622422+00:00 wowza2 kernel: [   24.976720] bond1: no IPv6 routers present
2015-01-07T12:32:26.867502+00:00 wowza2 ntpdate[2259]: step time server 132.163.4.102 offset 18000.497650 sec
2015-01-07T12:32:47.243665+00:00 wowza2 ntpdate[4445]: step time server 132.163.4.102 offset -0.000387 sec
2015-01-07T12:32:56.688632+00:00 wowza2 monit[5072]: monit: Status not available -- the monit daemon is not running
2015-01-07T12:32:58.916585+00:00 wowza2 monit[5095]: monit: Status not available -- the monit daemon is not running
2015-01-07T12:33:04.596379+00:00 wowza2 monit[5136]: Starting monit daemon with http interface at [*:2812]
2015-01-07T12:33:04.605071+00:00 wowza2 monit[5138]: Starting monit HTTP server at [*:2812]
2015-01-07T12:33:04.605110+00:00 wowza2 monit[5138]: monit HTTP server started
2015-01-07T12:33:04.605145+00:00 wowza2 monit[5138]: 'base' Monit started
2015-01-07T12:33:04.784132+00:00 wowza2 monit[5138]: 'wowza' process is not running
2015-01-07T12:33:04.860845+00:00 wowza2 monit[5138]: 'wowza' trying to restart
2015-01-07T12:33:04.860858+00:00 wowza2 monit[5138]: 'wowza' start: /etc/init.d/wowza
2015-01-07T12:33:04.938909+00:00 wowza2 monit[5138]: 'ntp' process is not running
2015-01-07T12:33:04.981225+00:00 wowza2 monit[5138]: 'ntp' trying to restart
2015-01-07T12:33:04.981237+00:00 wowza2 monit[5138]: 'ntp' start: /etc/init.d/ntp
2015-01-07T12:33:11.034930+00:00 wowza2 ntpdate[5068]: adjust time server 152.2.133.54 offset -0.001441 sec
2015-01-07T12:33:15.241148+00:00 wowza2 puppet-agent[3988]: (/Stage[main]/Wowza/Helper::Script[install wowza]/Exec[exec install wowza]/returns) executed successfully
[..]
2015-01-07T12:33:20.030527+00:00 wowza2 ntpd[5549]: ntpd 4.2.6p5@1.2349-o Sat Dec 20 17:54:34 UTC 2014 (1)
2015-01-07T12:33:20.031838+00:00 wowza2 ntpd[5550]: proto: precision = 0.134 usec
2015-01-07T12:33:20.032177+00:00 wowza2 ntpd[5550]: Listen and drop on 0 v4wildcard 0.0.0.0 UDP 123
2015-01-07T12:33:20.034176+00:00 wowza2 ntpd[5550]: Listen and drop on 1 v6wildcard :: UDP 123
2015-01-07T12:33:20.034300+00:00 wowza2 ntpd[5550]: Listen normally on 2 lo 127.0.0.1 UDP 123
2015-01-07T12:33:20.034316+00:00 wowza2 ntpd[5550]: Listen normally on 3 bond0 10.55.40.154 UDP 123
2015-01-07T12:33:20.034320+00:00 wowza2 ntpd[5550]: Listen normally on 4 bond1 50.23.93.244 UDP 123
2015-01-07T12:33:20.034407+00:00 wowza2 ntpd[5550]: Listen normally on 5 bond1 fe80::225:90ff:fef0:4fd7 UDP 123
2015-01-07T12:33:20.034419+00:00 wowza2 ntpd[5550]: Listen normally on 6 bond0 fe80::225:90ff:fef0:4fd6 UDP 123
2015-01-07T12:33:20.034423+00:00 wowza2 ntpd[5550]: Listen normally on 7 lo ::1 UDP 123
2015-01-07T12:33:20.034492+00:00 wowza2 ntpd[5550]: peers refreshed
2015-01-07T12:33:20.034507+00:00 wowza2 ntpd[5550]: Listening on routing socket on fd #24 for interface updates
2015-01-07T12:33:30.342676+00:00 wowza2 monit[5138]: 'wowza' process is running with pid 5619
2015-01-07T12:33:30.393932+00:00 wowza2 monit[5138]: 'ntp' process is running with pid 5550
2015-01-07T12:43:06.194254+00:00 wowza2 puppet-agent[8755]: (/Stage[main]/Wowza/Helper::Script[install wowza]/Exec[exec install wowza]/returns) executed successfully
[..]
```

Machine has not even finished booting, `puppet` is already started and installs wowza. This keeps happening at every subsequent puppet run (unless puppet is restarted).

The test in question (that fails) is in https://github.com/cargomedia/puppet-packages/blob/master/modules/wowza/manifests/init.pp#L19

Interestingly, there is another similar test (passing):
```
2015-01-07T13:12:39.943137+00:00 wowza2 puppet-agent[22728]: (Exec[exec install puppet apt sources](provider=shell)) Executing check '["/bin/sh", "-c", "dpkg -l puppetlabs-release | grep '^ii '"]'
2015-01-07T13:12:39.943593+00:00 wowza2 puppet-agent[22728]: Executing '/bin/sh -c dpkg -l puppetlabs-release | grep '^ii ''q
```

Compare to the failing test (this is a debug run and test *succeeded*):
```
2015-01-07T13:12:50.848683+00:00 wowza2 puppet-agent[22728]: (Exec[exec install wowza](provider=shell)) Executing check '["/bin/sh", "-c", "dpkg -l | grep -q '^ii.* wowzastreamingengine-4.0.3'"]'
2015-01-07T13:12:50.849084+00:00 wowza2 puppet-agent[22728]: Executing '/bin/sh -c dpkg -l | grep -q '^ii.* wowzastreamingengine-4.0.3''
```

Possibilities / Thoughts:
* puppet cache somehow leading to failing test
* puppet cache somehow corrupt
* test failing after rebooting (may be `dpkg -l` ?) but why at every subsequent run?

