### PR TITLE
Change runlevel to start puppet daemon

### DIFF
--- a/modules/bipbip/templates/init.sh
+++ b/modules/bipbip/templates/init.sh
@@ -4,7 +4,7 @@
 # Provides:				bipbip
 # Required-Start:		$syslog
 # Required-Stop:		$syslog
-# Default-Start:		2 3 4 5
+# Default-Start:		3 4 5
 # Default-Stop:			0 1 6
 # Short-Description:	Bipbip
 # Description:			Gather services data and store in CopperEgg

--- a/modules/copperegg_revealcloud/templates/init.sh
+++ b/modules/copperegg_revealcloud/templates/init.sh
@@ -5,7 +5,7 @@
 # Provides:				revealcloud
 # Required-Start:		$syslog
 # Required-Stop:		$syslog
-# Default-Start:		2 3 4 5
+# Default-Start:		3 4 5
 # Default-Stop:			0 1 6
 # Short-Description:	CopperEgg RevealCloud collector
 # Description:			CopperEgg RevealCloud collector

--- a/modules/mms/templates/init
+++ b/modules/mms/templates/init
@@ -4,7 +4,7 @@
 # Provides:						<%= @agent_name %>
 # Required-Start:			$syslog
 # Required-Stop:			$syslog
-# Default-Start:			2 3 4 5
+# Default-Start:			3 4 5
 # Default-Stop:				0 1 6
 # Short-Description:	<%= @agent_name %>
 # Description:				Get MongoDB cluster status and sens to MMS service

--- a/modules/puppet/templates/agent/init
+++ b/modules/puppet/templates/agent/init
@@ -4,7 +4,7 @@
 # Required-Start:    $network $named $remote_fs $syslog
 # Required-Stop:     $network $named $remote_fs $syslog
 # Should-Start:      puppet
-# Default-Start:     2 3 4 5
+# Default-Start:     3 4 5
 # Default-Stop:      0 1 6
 ### END INIT INFO
 

--- a/modules/socket_redis/templates/init.sh
+++ b/modules/socket_redis/templates/init.sh
@@ -4,7 +4,7 @@
 # Provides:          socket-redis
 # Required-Start:    $local_fs $syslog
 # Required-Stop:     $local_fs $syslog
-# Default-Start:     2 3 4 5
+# Default-Start:     3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Starts the socket-redis node script
 ### END INIT INFO


### PR DESCRIPTION
Resulting from insights gained while investigating #791 

`puppet` should start a bit later (runlevel 3 means networking has been started)

@tomaszdurka @njam @kris-lab opinions? agree? thoughts?