### PR TITLE
Always output vagrant box output in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ RSpec.configure do |c|
   c.add_setting :before_files
   c.before_files = []
   root_dir = Dir.getwd
-  vagrant_helper = VagrantHelper.new(root_dir, box, debug ? true : false)
+  vagrant_helper = VagrantHelper.new(root_dir, box, true)
 
   c.before :all do
     file = self.get_file


### PR DESCRIPTION
In #714 the output in specs was reduced.
I think we should always see what resources are being changed in spec output, as it's very important for development.
Using `debug=true` is not really an alternative as its output is way to much for normal development.
I'd suggest to just forward puppet output from the VM.

Before:
```
modules/puppet/spec/agent/spec.rb
/usr/local/Cellar/ruby/2.1.5/bin/ruby -I/usr/local/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.4/lib:/usr/local/lib/ruby/gems/2.1.0/gems/rspec-support-3.0.4/lib -S /usr/local/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.4/exe/rspec modules/puppet/spec/agent/spec.rb

Running `/vagrant/modules/puppet/spec/agent/manifest.pp`
.....

Finished in 7.55 seconds (files took 0.34959 seconds to load)
5 examples, 0 failures
```

After:
```
modules/puppet/spec/agent/spec.rb
/usr/local/Cellar/ruby/2.1.5/bin/ruby -I/usr/local/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.4/lib:/usr/local/lib/ruby/gems/2.1.0/gems/rspec-support-3.0.4/lib -S /usr/local/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.4/exe/rspec modules/puppet/spec/agent/spec.rb
vagrant ssh-config wheezy

Running `/vagrant/modules/puppet/spec/agent/manifest.pp`
Notice: Compiled catalog for debian-7-amd64-default.vagrantup.com in environment production in 1.30 seconds

Notice: /Stage[main]/Puppet::Agent/File[/etc/default/puppet]/mode: mode changed '0644' to '0640'

Notice: /Stage[main]/Puppet::Agent/Service[puppet]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Puppet::Agent/Exec[update-rc.d puppet defaults && /etc/init.d/puppet start]: Triggered 'refresh' from 1 events
Notice: Finished catalog run in 1.23 seconds
.....

Finished in 8.41 seconds (files took 0.23933 seconds to load)
5 examples, 0 failures
```

@kris-lab @ppp0 wdyt?