### PR TITLE
Pass "passphrase" to ssh-keygen, make command execution more robust

### DIFF
--- a/modules/ssh/lib/puppet/parser/functions/generate_sshkey.rb
+++ b/modules/ssh/lib/puppet/parser/functions/generate_sshkey.rb
@@ -7,7 +7,9 @@ module Puppet::Parser::Functions
     key_file = "/var/lib/puppet/ssh-repository/#{name}"
     unless File.exists? key_file
       FileUtils.mkdir_p File.dirname key_file
-      `/usr/bin/ssh-keygen -t ssh-rsa -f #{Shellwords.escape(key_file)} -C #{Shellwords.escape(name)}`
+      unless Kernel.system("/usr/bin/ssh-keygen -t ssh-rsa -N '' -f #{Shellwords.escape(key_file)} -C #{Shellwords.escape(name)}")
+        raise Puppet::ParseError, "Failed to generate SSH key `#{name}`."
+      end
     end
     private = File.read(key_file)
     public = File.read(key_file + '.pub')

--- a/modules/ssh/lib/puppet/parser/functions/generate_sshkey.rb
+++ b/modules/ssh/lib/puppet/parser/functions/generate_sshkey.rb
@@ -7,7 +7,7 @@ module Puppet::Parser::Functions
     key_file = "/var/lib/puppet/ssh-repository/#{name}"
     unless File.exists? key_file
       FileUtils.mkdir_p File.dirname key_file
-      unless Kernel.system("/usr/bin/ssh-keygen -t ssh-rsa -N '' -f #{Shellwords.escape(key_file)} -C #{Shellwords.escape(name)}")
+      unless Kernel.system("/usr/bin/ssh-keygen -q -t ssh-rsa -N '' -f #{Shellwords.escape(key_file)} -C #{Shellwords.escape(name)}")
         raise Puppet::ParseError, "Failed to generate SSH key `#{name}`."
       end
     end


### PR DESCRIPTION
Puh this took me a long time to debug. `ssh-keygen` was asking for a passphrase on the terminal (within passenger), and everything got stuck indefinitely as a result.
@tomaszdurka @ppp0 @kris-lab please review