### PR TITLE
Define for composer create-project

### DIFF
--- a/modules/composer/manifests/project.pp
+++ b/modules/composer/manifests/project.pp
@@ -1,15 +1,14 @@
 define composer::project (
-  $source = $name,
-  $target = "/usr/local/composer/${source}",
+  $target = "/usr/local/composer/${name}",
+  $version,
   $user = 'root',
   $home = '/root',
   $stability = 'stable',
 ) {
-
   require 'composer'
 
   exec {"install ${name}":
-    command => "composer --no-interaction create-project ${source} --stability=${stability} --keep-vcs ${target}",
+    command => "composer --no-interaction create-project ${name} --stability=${stability} --keep-vcs ${target}",
     creates => $target,
     path => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     user => $user,

--- a/modules/composer/manifests/project.pp
+++ b/modules/composer/manifests/project.pp
@@ -9,7 +9,7 @@ define composer::project (
   require 'composer'
 
   exec {"install ${name}":
-    command => "composer --no-interaction create-project composer/satis --stability=${stability} --keep-vcs ${target}",
+    command => "composer --no-interaction create-project ${source} --stability=${stability} --keep-vcs ${target}",
     creates => $target,
     path => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     user => $user,
@@ -18,7 +18,7 @@ define composer::project (
   }
   ->
 
-  exec {'upgrade satis':
+  exec {"upgrade ${name}":
     command => "git fetch && git checkout ${version} && composer --no-interaction --no-dev install",
     cwd => $target,
     unless => "test $(git rev-parse HEAD) = $(git rev-parse ${version})",

--- a/modules/composer/manifests/project.pp
+++ b/modules/composer/manifests/project.pp
@@ -1,0 +1,29 @@
+define composer::project (
+  $source = $name,
+  $target = "/usr/local/composer/${source}",
+  $user = 'root',
+  $home = '/root',
+) {
+
+  require 'composer'
+
+  exec {"install ${name}":
+    command => "composer --no-interaction create-project composer/satis --stability=dev --keep-vcs ${target}",
+    creates => $target,
+    path => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    user => $user,
+    environment => ["HOME=${home}"],
+    require => Class['composer'],
+  }
+  ->
+
+  exec {'upgrade satis':
+    command => "git fetch && git checkout ${version} && composer --no-interaction --no-dev install",
+    cwd => $target,
+    unless => "test $(git rev-parse HEAD) = $(git rev-parse ${version})",
+    path => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    user => $user,
+    environment => ["HOME=${home}"],
+    require => Class['composer'],
+  }
+}

--- a/modules/composer/manifests/project.pp
+++ b/modules/composer/manifests/project.pp
@@ -3,12 +3,13 @@ define composer::project (
   $target = "/usr/local/composer/${source}",
   $user = 'root',
   $home = '/root',
+  $stability = 'stable',
 ) {
 
   require 'composer'
 
   exec {"install ${name}":
-    command => "composer --no-interaction create-project composer/satis --stability=dev --keep-vcs ${target}",
+    command => "composer --no-interaction create-project composer/satis --stability=${stability} --keep-vcs ${target}",
     creates => $target,
     path => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     user => $user,

--- a/modules/composer/spec/project/1-install.pp
+++ b/modules/composer/spec/project/1-install.pp
@@ -1,0 +1,8 @@
+node default {
+
+  composer::project{ 'phpunit/phpunit':
+    user      => 'root',
+    version   => '4.3.4',
+    stability => 'dev',
+  }
+}

--- a/modules/composer/spec/project/2-upgrade.pp
+++ b/modules/composer/spec/project/2-upgrade.pp
@@ -1,0 +1,8 @@
+node default {
+
+  composer::project{ 'phpunit/phpunit':
+    user      => 'root',
+    version   => '4.4.0',
+    stability => 'dev',
+  }
+}

--- a/modules/composer/spec/project/manifest.pp
+++ b/modules/composer/spec/project/manifest.pp
@@ -1,0 +1,9 @@
+node default {
+
+  composer::project{ 'composer/satis':
+    target    => '/var/lib/satis/satis',
+    user      => 'root',
+    home      => '/var/lib/satis',
+    stability => 'dev',
+  }
+}

--- a/modules/composer/spec/project/manifest.pp
+++ b/modules/composer/spec/project/manifest.pp
@@ -1,9 +1,0 @@
-node default {
-
-  composer::project{ 'composer/satis':
-    target    => '/var/lib/satis/satis',
-    user      => 'root',
-    home      => '/var/lib/satis',
-    stability => 'dev',
-  }
-}

--- a/modules/composer/spec/project/spec.rb
+++ b/modules/composer/spec/project/spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
-describe command('/var/lib/satis/satis/bin/satis') do
+describe command('/usr/local/composer/phpunit/phpunit/phpunit --version') do
   it { should return_exit_status 0 }
+  its(:stdout) { should match /PHPUnit 4\.4\.0 / }
 end

--- a/modules/composer/spec/project/spec.rb
+++ b/modules/composer/spec/project/spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe command('/var/lib/satis/satis/bin/satis') do
+  it { should return_exit_status 0 }
+end


### PR DESCRIPTION
Something like
```pp
composer::project { $repository:
  ensure => present,
  source => 'cargomedia/s3export_backup'
  target => $path,
  dev    => true,
}
```

would come in handy!

---

Should also update to certain version via `git`. See `class satis`:
```pp
  exec {'install satis':
    command => 'composer --no-interaction create-project composer/satis --stability=dev --keep-vcs /var/lib/satis/satis',
    creates => '/var/lib/satis/satis',
    path => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
    user => 'satis',
    environment => ['HOME=/var/lib/satis'],
  }
  ->

  exec {'upgrade satis':
    command => "git fetch && git checkout ${version} && composer --no-interaction --no-dev install",
    cwd => '/var/lib/satis/satis',
    unless => "test $(git rev-parse HEAD) = ${version}",
    path => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
    user => 'satis',
    environment => ['HOME=/var/lib/satis'],
  }
```