### PR TITLE
Use short gpg key fingerprint

### DIFF
--- a/modules/deb_multimedia/manifests/init.pp
+++ b/modules/deb_multimedia/manifests/init.pp
@@ -4,7 +4,7 @@ class deb_multimedia {
     entries => [ "deb http://www.deb-multimedia.org ${::lsbdistcodename} main non-free" ],
     keys => {
       'debian-multimedia' => {
-        key => '5C808C2B65558117',
+        key => '65558117',
         key_server => 'pgp.mit.edu'
       }
     }


### PR DESCRIPTION
Followup of #815

Need to use short key fingerprint, otherwise it will not match the output of `apt-key list` and install over and over again..