### PR TITLE
ruby::gem::nokogiri fail to install

### DIFF
--- a/modules/ruby/manifests/gem/nokogiri.pp
+++ b/modules/ruby/manifests/gem/nokogiri.pp
@@ -2,7 +2,7 @@ class ruby::gem::nokogiri ($version = 'present') {
 
   require 'build'
 
-  package {['libxslt1-dev', 'libxml2-dev']:
+  package {['libxslt1-dev', 'libxml2-dev', 'zlib1g-dev']:
     ensure => present
   }
 


### PR DESCRIPTION
`nokogiri` on debian requires the lib `zlib1g-dev` [see](http://www.nokogiri.org/tutorials/installing_nokogiri.html)