### PR TITLE
composer::project keeps reinstalling/upgrading

### DIFF
--- a/modules/composer/manifests/project.pp
+++ b/modules/composer/manifests/project.pp
@@ -20,7 +20,7 @@ define composer::project (
   exec { "upgrade ${name}":
     command     => "git fetch && git checkout ${version} && composer --no-interaction --no-dev install",
     cwd         => $target,
-    unless      => "test $(git rev-parse HEAD) = $(git rev-parse ${version})",
+    unless      => "test $(git rev-list -1 HEAD) = $(git rev-list -1 ${version})",
     path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     user        => $user,
     environment => ["HOME=${home}"],

--- a/modules/composer/spec/project/1-install.pp
+++ b/modules/composer/spec/project/1-install.pp
@@ -1,9 +1,9 @@
 node default {
 
-  composer::project{ 'phpunit/phpunit':
-    target    => '/usr/local/lib/phpunit',
+  composer::project{ 'seld/jsonlint':
+    target    => '/usr/local/lib/jsonlint',
     user      => 'root',
-    version   => '4.3.4',
+    version   => '1.2.0',
     stability => 'dev',
   }
 }

--- a/modules/composer/spec/project/2-upgrade.pp
+++ b/modules/composer/spec/project/2-upgrade.pp
@@ -1,9 +1,9 @@
 node default {
 
-  composer::project{ 'phpunit/phpunit':
-    target    => '/usr/local/lib/phpunit',
+  composer::project{ 'seld/jsonlint':
+    target    => '/usr/local/lib/jsonlint',
     user      => 'root',
-    version   => '4.4.0',
+    version   => '1.3.1',
     stability => 'dev',
   }
 }

--- a/modules/composer/spec/project/spec.rb
+++ b/modules/composer/spec/project/spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 
-describe command('/usr/local/lib/phpunit/phpunit --version') do
+describe command('/usr/local/lib/jsonlint/bin/jsonlint --help') do
   it { should return_exit_status 0 }
-  its(:stdout) { should match /PHPUnit 4\.4\.0 / }
 end


### PR DESCRIPTION
This test seems to fail (example is from s3export_backup):
```sh
test $(git rev-parse HEAD) = $(git rev-parse 0.2.0)
``` 

see https://github.com/cargomedia/puppet-packages/blob/master/modules/composer/manifests/project.pp#L23

Executed manually:
```sh
$ git rev-parse 0.2.0
9e750872257187d7325df38b10139077b35ca615
$ git rev-parse HEAD
5d69193c0f6e41a670d7e968ee9d1d1dd159784c
```
