### PR TITLE
Introduce hash-based argument-passing for cm::vhost

### DIFF
--- a/modules/cm/manifests/vhost.pp
+++ b/modules/cm/manifests/vhost.pp
@@ -3,7 +3,7 @@ define cm::vhost(
   $ssl_cert = undef,
   $ssl_key = undef,
   $aliases = [],
-  $redirect = undef,
+  $redirects = undef,
   $cdn_origin = undef,
   $debug = false
 ) {
@@ -17,11 +17,11 @@ define cm::vhost(
 
 
 
-  if ($redirect) {
+  if ($redirects) {
     $protocol = $ssl ? { true => 'https', false => 'http' }
     nginx::resource::vhost{ "${name}-redirect":
       listen_port         => 80,
-      server_name         => $redirect,
+      server_name         => $redirects,
       location_cfg_append => [
         "return 301 ${protocol}://${name}\$request_uri;",
       ],


### PR DESCRIPTION
As a follow-up of #851 

We want to be able to pass a `redirects` list to arbitrary `hostnames`..

Example (hiera):
```
    "sk::www::vhosts": [
      {
        "domain": "foo.com",
        "aliases": ["www.foo.com", "admin.foo.com"]
      },
      {
        "domain": "oh.net",
        "aliases": ["www.oh.net", "admin.oh.net"],
        "redirects": ["ah.net", "uh.net"],
      }
    ]
```

