### PR TITLE
Make "monit-alert.sh" wait for (optional) monit restart

### DIFF
--- a/modules/monit/templates/bin/monit-alert.sh
+++ b/modules/monit/templates/bin/monit-alert.sh
@@ -17,16 +17,16 @@ ln -s ${SOURCE} ${DEST}
 function monitGetStateFileAccess { stat -c "%Y" "/root/.monit.state"; }
 export -f monitGetStateFileAccess
 export MONIT_STATE_FILE_ACCESS=$(monitGetStateFileAccess)
-function monitHasStateChanged { test "$(monitGetStateFileAccess)" != "${MONIT_STATE_FILE_ACCESS}"; }
-export -f monitHasStateChanged
+function waitForMonitStateChange { timeout --signal=9 $1 bash -c 'while ! (test "$(monitGetStateFileAccess)" != "${MONIT_STATE_FILE_ACCESS}"); do sleep 0.05; done'; }
+export -f waitForMonitStateChange
 
 monit reload
 
-if ! (timeout --signal=9 5 bash -c "while ! (monitHasStateChanged); do sleep 0.05; done"); then
+if ! (waitForMonitStateChange 5); then
   # Hard-restart monit in case it cannot reload
   /etc/init.d/monit restart
 
-  if ! (timeout --signal=9 10 bash -c "while ! (monitHasStateChanged); do sleep 0.05; done"); then
+  if ! (waitForMonitStateChange 10); then
     exit 1
   fi
 fi

--- a/modules/monit/templates/bin/monit-alert.sh
+++ b/modules/monit/templates/bin/monit-alert.sh
@@ -26,3 +26,7 @@ if ! (timeout --signal=9 5 bash -c "while ! (monitCheckHasReloaded); do sleep 0.
   # Hard-restart monit in case it cannot reload
   /etc/init.d/monit restart
 fi
+
+if ! (timeout --signal=9 10 bash -c "while ! (monitCheckHasReloaded); do sleep 0.05; done"); then
+  exit 1
+fi

--- a/modules/monit/templates/bin/monit-alert.sh
+++ b/modules/monit/templates/bin/monit-alert.sh
@@ -25,8 +25,9 @@ monit reload
 if ! (timeout --signal=9 5 bash -c "while ! (monitHasStateChanged); do sleep 0.05; done"); then
   # Hard-restart monit in case it cannot reload
   /etc/init.d/monit restart
+
+  if ! (timeout --signal=9 10 bash -c "while ! (monitHasStateChanged); do sleep 0.05; done"); then
+    exit 1
+  fi
 fi
 
-if ! (timeout --signal=9 10 bash -c "while ! (monitHasStateChanged); do sleep 0.05; done"); then
-  exit 1
-fi

--- a/modules/monit/templates/bin/monit-alert.sh
+++ b/modules/monit/templates/bin/monit-alert.sh
@@ -17,16 +17,16 @@ ln -s ${SOURCE} ${DEST}
 function monitGetStateFileAccess { stat -c "%Y" "/root/.monit.state"; }
 export -f monitGetStateFileAccess
 export MONIT_STATE_FILE_ACCESS=$(monitGetStateFileAccess)
-function monitCheckHasReloaded { test "$(monitGetStateFileAccess)" != "${MONIT_STATE_FILE_ACCESS}"; }
-export -f monitCheckHasReloaded
+function monitHasStateChanged { test "$(monitGetStateFileAccess)" != "${MONIT_STATE_FILE_ACCESS}"; }
+export -f monitHasStateChanged
 
 monit reload
 
-if ! (timeout --signal=9 5 bash -c "while ! (monitCheckHasReloaded); do sleep 0.05; done"); then
+if ! (timeout --signal=9 5 bash -c "while ! (monitHasStateChanged); do sleep 0.05; done"); then
   # Hard-restart monit in case it cannot reload
   /etc/init.d/monit restart
 fi
 
-if ! (timeout --signal=9 10 bash -c "while ! (monitCheckHasReloaded); do sleep 0.05; done"); then
+if ! (timeout --signal=9 10 bash -c "while ! (monitHasStateChanged); do sleep 0.05; done"); then
   exit 1
 fi


### PR DESCRIPTION
In case of problems detecting monit's `reload` in `monit-alert.sh` we do a `restart` instead:
```sh
if ! (timeout --signal=9 5 bash -c "while ! (monitCheckHasReloaded); do sleep 0.05; done"); then
  # Hard-restart monit in case it cannot reload
  /etc/init.d/monit restart
fi
```

This restart is not blocking, so the next script to run might find a stopped monit. We should make sure monit is fully restarted after the script finished.