### PR TITLE
Pulsar rest api test fails with newest package

### DIFF
--- a/modules/pulsar_rest_api/manifests/init.pp
+++ b/modules/pulsar_rest_api/manifests/init.pp
@@ -11,7 +11,7 @@ class pulsar_rest_api (
   $pulsar_repo = undef,
   $pulsar_branch = undef,
 
-  $auth = undef,
+  $authentication = undef,
 ) {
 
   require bower

--- a/modules/pulsar_rest_api/spec/init/manifest.pp
+++ b/modules/pulsar_rest_api/spec/init/manifest.pp
@@ -9,11 +9,15 @@ node default {
     pulsar_repo    => 'foo/bar',
     pulsar_branch  => 'master',
 
-    auth           => {
+    authentication => {
       'github_oauth_id' => 'id',
       'github_oauth_secret' => 'secret',
       'github_org' => 'org',
       'base_url' => 'base_url',
+      'authorization' => {
+        'read' => 'read-org',
+        'write' => 'write-org',
+      }
     },
   }
 }

--- a/modules/pulsar_rest_api/spec/init/spec.rb
+++ b/modules/pulsar_rest_api/spec/init/spec.rb
@@ -10,6 +10,14 @@ describe 'pulsar_rest_api' do
     it { should be_installed.by('npm') }
   end
 
+  describe file('/etc/pulsar-rest-api/config.yml') do
+    its(:content) { should include "repo: 'foo/bar'" }
+    its(:content) { should include "branch: 'master'" }
+    its(:content) { should include "githubOauthSecret: 'secret'"}
+    its(:content) { should include "read: ['read-org']" }
+    its(:content) { should include "write: ['write-org']" }
+  end
+
   describe port(8080) do
     it { should be_listening }
   end

--- a/modules/pulsar_rest_api/templates/config.yml
+++ b/modules/pulsar_rest_api/templates/config.yml
@@ -9,10 +9,15 @@ pulsar:
   branch: '<%= @pulsar_branch %>'
 <% end -%>
 logPath: '<%= @log_dir %>/pulsar-rest-api.log'
-<% if @auth -%>
-auth:
-  githubOauthId: '<%= @auth['github_oauth_id'] %>'
-  githubOauthSecret: '<%= @auth['github_oauth_secret'] %>'
-  githubOrg: '<%= @auth['github_org'] %>'
-  baseUrl: '<%= @auth['base_url'] %>'
+<% if @authentication -%>
+authentication:
+  githubOauthId: '<%= @authentication['github_oauth_id'] %>'
+  githubOauthSecret: '<%= @authentication['github_oauth_secret'] %>'
+  githubOrg: '<%= @authentication['github_org'] %>'
+  baseUrl: '<%= @authentication['base_url'] %>'
+<% if @authentication['authorization'] -%>
+  authorization:
+    read: ['<%= @authentication['authorization']['read'] %>']
+    write: ['<%= @authentication['authorization']['write'] %>']
+<% end -%>
 <% end -%>


### PR DESCRIPTION
```
1) pulsar_rest_api Command "curl -I localhost:8080" stdout should match "location: https://github.com/login/oauth/authorize"
     Failure/Error: its(:stdout) { should match 'location: https://github.com/login/oauth/authorize' }
       expected "HTTP/1.1 302 Moved Temporarily\nX-Powered-By: Express\nLocation: /web\nVary: Accept\nContent-Type: text/plain; charset=utf-8\nContent-Length: 38\nDate: Fri, 27 Feb 2015 05:02:06 GMT\nConnection: keep-alive\n\n" to match "location: https://github.com/login/oauth/authorize"
       Diff:
       @@ -1,2 +1,9 @@
       -location: https://github.com/login/oauth/authorize
       +HTTP/1.1 302 Moved Temporarily
       +X-Powered-By: Express
       +Location: /web
       +Vary: Accept
       +Content-Type: text/plain; charset=utf-8
       +Content-Length: 38
       +Date: Fri, 27 Feb 2015 05:02:06 GMT
       +Connection: keep-alive

     # ./modules/pulsar_rest_api/spec/init/spec.rb:19:in `block (3 levels) in <top (required)>'
```