### PR TITLE
Increase monit's default load alerting thresholds

### DIFF
--- a/modules/monit/manifests/entry/system.pp
+++ b/modules/monit/manifests/entry/system.pp
@@ -1,6 +1,7 @@
 class monit::entry::system(
   $alertOnLoad1 = undef,
-  $alertOnLoad5 = undef
+  $alertOnLoad5 = undef,
+  $alertOnLoad15 = undef
 ) {
 
   require '::monit'

--- a/modules/monit/templates/entry/system
+++ b/modules/monit/templates/entry/system
@@ -1,7 +1,7 @@
 check system base
 	if loadavg(1min) > <%= @alertOnLoad1 ? @alertOnLoad1 : (5.0 * @processorcount.to_f).ceil %> then alert
 	if loadavg(5min) > <%= @alertOnLoad5 ? @alertOnLoad5 : (2.0 * @processorcount.to_f).ceil %> then alert
-	if loadavg(15min) > <%= @alertOnLoad15 ? @alertOnLoad15 : (1.0 * @processorcount.to_f).ceil %> then alert
+	if loadavg(15min) > <%= @alertOnLoad15 ? @alertOnLoad15 : (0.8 * @processorcount.to_f).ceil %> then alert
 	if memory > 85% then alert
 
 check filesystem root with path /

--- a/modules/monit/templates/entry/system
+++ b/modules/monit/templates/entry/system
@@ -1,6 +1,7 @@
 check system base
-	if loadavg(1min) > <%= @alertOnLoad1 ? @alertOnLoad1 : (1.5 * @processorcount.to_f).ceil %> then alert
-	if loadavg(5min) > <%= @alertOnLoad5 ? @alertOnLoad5 : (0.6 * @processorcount.to_f).ceil %> then alert
+	if loadavg(1min) > <%= @alertOnLoad1 ? @alertOnLoad1 : (5.0 * @processorcount.to_f).ceil %> then alert
+	if loadavg(5min) > <%= @alertOnLoad5 ? @alertOnLoad5 : (2.0 * @processorcount.to_f).ceil %> then alert
+	if loadavg(15min) > <%= @alertOnLoad15 ? @alertOnLoad15 : (1.0 * @processorcount.to_f).ceil %> then alert
 	if memory > 85% then alert
 
 check filesystem root with path /


### PR DESCRIPTION
See e.g. http://blog.scoutapp.com/articles/2009/07/31/understanding-load-averages
Related to https://github.com/cargomedia/puppet-cargomedia/issues/659

@cargomedia/devops wdyt?