### PR TITLE
Change default bipbip frequency to 15

### DIFF
--- a/modules/bipbip/manifests/init.pp
+++ b/modules/bipbip/manifests/init.pp
@@ -1,7 +1,7 @@
 class bipbip (
   $api_key,
   $version = 'latest',
-  $frequency = 5,
+  $frequency = 15,
   $tags = $::copperegg_tags,
   $log_file = '/var/log/bipbip/bipbip.log',
   $log_level = 'INFO',


### PR DESCRIPTION
CopperEgg's API still supports 5secs, but the value is then stored as 15sec, so no need to measure more often

@ppp0 @kris-lab please review