### PR TITLE
Increase monit reload timeout from 10 to 30 secs

### DIFF
--- a/modules/monit/templates/bin/monit-alert.sh
+++ b/modules/monit/templates/bin/monit-alert.sh
@@ -21,5 +21,5 @@ function waitForMonitReload { timeout --signal=9 $1 bash -c 'while ! (test "$(ge
 
 if (pidof monit >/dev/null); then
   kill -s SIGHUP $(pidof monit)
-  waitForMonitReload 10
+  waitForMonitReload 30
 fi


### PR DESCRIPTION
When monit is busy with starting/stopping daemons (e.g. after starting up), it can take a bit to process the SIGHUP and reload

This can be reproduced for example with:
```
/etc/init.d/monit stop
monit stop puppet
/etc/init.d/monit start
monit-alert default
```