### PR TITLE
Spec failing: wowza::app::cm

### DIFF
--- a/modules/wowza/manifests/init.pp
+++ b/modules/wowza/manifests/init.pp
@@ -1,6 +1,6 @@
 class wowza (
   $version = '4.0.3',
-  $license = 'ET1A4-rxCap-8rRZK-anCke-QYRhH-V8Prb-7bkWraz76eN8',
+  $license = 'EDEV4-SaTE3-BDYtA-B66CJ-BPmH8-ebDEE-UPU3B3wcBJy',
   $admin_user = 'root',
   $admin_password = 'root'
 ) {


### PR DESCRIPTION
Since May 8th:
```
Failures:

  1) wowza::app::cm Port "1935" should be listening
     Failure/Error: it { should be_listening }
       expected Port "1935" to be listening
       sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ :1935\\\

     # ./modules/wowza/spec/app-cm/spec.rb:38:in `block (4 levels) in <top (required)>'

  2) wowza::app::cm Port "8083" should be listening
     Failure/Error: it { should be_listening }
       expected Port "8083" to be listening
       sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ :8083\\\

     # ./modules/wowza/spec/app-cm/spec.rb:38:in `block (4 levels) in <top (required)>'

  3) wowza::app::cm Port "8086" should be listening
     Failure/Error: it { should be_listening }
       expected Port "8086" to be listening
       sudo -p 'Password: ' /bin/sh -c netstat\ -tunl\ \|\ grep\ --\ :8086\\\

     # ./modules/wowza/spec/app-cm/spec.rb:38:in `block (4 levels) in <top (required)>'

  4) wowza::app::cm Command "curl http://localhost:8086/status" stdout should eq "{}"
     Failure/Error: its(:stdout) { should eq '{}' }

       expected: "{}"
            got: ""

       (compared using ==)
       sudo -p 'Password: ' /bin/sh -c curl\ http://localhost:8086/status

     # ./modules/wowza/spec/app-cm/spec.rb:49:in `block (3 levels) in <top (required)>'
```

@kris-lab can you have a look?