### PR TITLE
pulsar-rest-api spec is falling

### DIFF
--- a/modules/pulsar_rest_api/manifests/init.pp
+++ b/modules/pulsar_rest_api/manifests/init.pp
@@ -69,7 +69,7 @@ class pulsar_rest_api (
   }
 
   exec { 'pulsar-rest-api bower install':
-    command     => 'bower install --production --allow-root',
+    command     => 'bower install --config.interactive=false --production --allow-root',
     cwd         => '/usr/lib/node_modules/pulsar-rest-api',
     path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     refreshonly => true,


### PR DESCRIPTION
````
Failed examples:

rspec ./modules/pulsar_rest_api/spec/init/spec.rb:6 # pulsar_rest_api User "pulsar-rest-api"
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:10 # pulsar_rest_api Package "pulsar-rest-api"
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:14 # pulsar_rest_api File "/etc/pulsar-rest-api/config.yml" content
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:15 # pulsar_rest_api File "/etc/pulsar-rest-api/config.yml" content
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:16 # pulsar_rest_api File "/etc/pulsar-rest-api/config.yml" content
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:17 # pulsar_rest_api File "/etc/pulsar-rest-api/config.yml" content
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:18 # pulsar_rest_api File "/etc/pulsar-rest-api/config.yml" content
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:22 # pulsar_rest_api Port "8080"
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:26 # pulsar_rest_api Command "curl -I localhost:8080" exit_status
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:27 # pulsar_rest_api Command "curl -I localhost:8080" stdout
rspec ./modules/pulsar_rest_api/spec/init/spec.rb:31 # pulsar_rest_api Command "monit summary" stdout
```