### PR TITLE
jenkins::plugin doesn't check installed plugin's version

### DIFF
--- a/modules/jenkins/manifests/plugin.pp
+++ b/modules/jenkins/manifests/plugin.pp
@@ -9,7 +9,7 @@ define jenkins::plugin($version) {
   exec { "install jenkins plugin ${name}":
     command => "curl -sL ${url} > ${path}",
     path    => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-    creates => $path,
+    unless  => "grep 'Plugin-Version: ${version}' /var/lib/jenkins/plugins/${name}/META-INF/MANIFEST.MF",
     user    => 'jenkins',
     notify  => Service['jenkins'],
   }

--- a/modules/jenkins/spec/plugin-upgrade/01-install.pp
+++ b/modules/jenkins/spec/plugin-upgrade/01-install.pp
@@ -1,0 +1,10 @@
+node default {
+
+  class { 'jenkins':
+    hostname => 'example.com'
+  }
+
+  jenkins::plugin { 'ssh-agent':
+    version => '1.3',
+  }
+}

--- a/modules/jenkins/spec/plugin-upgrade/02-upgrade.pp
+++ b/modules/jenkins/spec/plugin-upgrade/02-upgrade.pp
@@ -1,0 +1,10 @@
+node default {
+
+  class { 'jenkins':
+    hostname => 'example.com'
+  }
+
+  jenkins::plugin { 'ssh-agent':
+    version => '1.7',
+  }
+}

--- a/modules/jenkins/spec/plugin-upgrade/spec.rb
+++ b/modules/jenkins/spec/plugin-upgrade/spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'jenkins::plugin-upgrade' do
+
+  # Wait for jenkins to start up
+  describe command('timeout --signal=9 30 bash -c "while ! (curl -s http://localhost:8080/ | grep -q "Dashboard"); do sleep 0.5; done"') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe command('cat /var/lib/jenkins/plugins/ssh-agent/META-INF/MANIFEST.MF') do
+    its(:stdout) { should match /Plugin-Version: 1.7/ }
+  end
+
+end


### PR DESCRIPTION
Possibly use something like:
```
cat /var/lib/jenkins/plugins/<PLUGIN>/META-INF/MANIFEST.MF | grep 'Plugin-Version:'
```