### PR TITLE
cm::vhost: Remove serving of /library and /vendor

### DIFF
--- a/modules/cm/manifests/vhost.pp
+++ b/modules/cm/manifests/vhost.pp
@@ -71,23 +71,6 @@ define cm::vhost(
     try_files => ['/maintenance.html', 'something-nonexistent'],
   }
 
-  if ($debug) {
-    nginx::resource::location{ "${name}-library":
-      vhost    => $name,
-      ssl      => $ssl,
-      ssl_only => $ssl,
-      location => '/library/',
-      www_root => $path,
-    }
-
-    nginx::resource::location{ "${name}-vendor":
-      vhost    => $name,
-      ssl      => $ssl,
-      ssl_only => $ssl,
-      location => '/vendor/',
-      www_root => $path,
-    }
-  }
 
   if ($cdn_origin) {
     $cdn_origin_vhost = "${name}-origin"


### PR DESCRIPTION
See https://github.com/cargomedia/puppet-packages/blob/master/modules/cm/manifests/vhost.pp#L74

Once https://github.com/cargomedia/CM/pull/1805 is deployed