### PR TITLE
Fix lvm spec

### DIFF
--- a/modules/lvm/spec/default/manifests.pp
+++ b/modules/lvm/spec/default/manifests.pp
@@ -1,7 +1,18 @@
 node default {
 
+  package { ['mount', 'util-linux']:
+    ensure => present,
+  }
+  ->
+
+  helper::script { 'Setup temporary loop device':
+    content => 'TMP=$(mktemp);dd if=/dev/zero of=${TMP} bs=100 count=1M;losetup /dev/loop0 ${TMP}',
+    unless  => "lsblk | grep -q loop0",
+  }
+  ->
+
   class { 'lvm::install':
-    physicalDevice          => '/dev/sdb',
+    physicalDevice          => '/dev/loop0',
     volumeGroupName         => 'vg01',
     logicalVolumeName       => 'storage01',
     logicalVolumeSize       => '50%',

--- a/modules/lvm/spec/default/manifests.pp
+++ b/modules/lvm/spec/default/manifests.pp
@@ -6,8 +6,8 @@ node default {
   ->
 
   helper::script { 'Setup temporary loop device':
-    content => 'TMP=$(mktemp);dd if=/dev/zero of=${TMP} bs=100 count=1M;losetup /dev/loop0 ${TMP}',
-    unless  => "lsblk | grep -q loop0",
+    content => "TMP=$(mktemp);dd if=/dev/zero of=${TMP} bs=100 count=1M;losetup /dev/loop0 ${TMP}",
+    unless  => 'lsblk | grep -q loop0',
   }
   ->
 

--- a/modules/lvm/spec/default/manifests.pp
+++ b/modules/lvm/spec/default/manifests.pp
@@ -6,7 +6,7 @@ node default {
   ->
 
   helper::script { 'Setup temporary loop device':
-    content => "TMP=$(mktemp);dd if=/dev/zero of=${TMP} bs=100 count=1M;losetup /dev/loop0 ${TMP}",
+    content => 'TMP=$(mktemp);dd if=/dev/zero of=$TMP bs=100 count=1M;losetup /dev/loop0 $TMP',
     unless  => 'lsblk | grep -q loop0',
   }
   ->

--- a/modules/lvm/spec/default/spec.rb
+++ b/modules/lvm/spec/default/spec.rb
@@ -33,8 +33,4 @@ describe 'lvm' do
   describe command('which xfs_growfs') do
     its(:exit_status) { should eq 0 }
   end
-
-  describe file('/root/bin/expand-raid.sh') do
-    it { should be_file }
-  end
 end


### PR DESCRIPTION
Secondary disk in virtualbox (`/dev/sdb`) was removed here: https://github.com/cargomedia/puppet-packages/pull/916
(The problem with the previous approach was that the `Vagrantfile` is declarative, so we can't check if the disk's file already exists with ruby, and then call `vb.customize ['createhd' ...` if not, because it will run this customization multiple times.)

@ppp0 maybe there's a way to refactor the LVM spec to work differently? Could we create a "pseudo disk" device on the fly?