### PR TITLE
Mongod: Timeout due to journal preallocation

### DIFF
--- a/modules/mongodb/manifests/core/mongod.pp
+++ b/modules/mongodb/manifests/core/mongod.pp
@@ -48,7 +48,7 @@ define mongodb::core::mongod (
   exec { "wait for ${instance_name} up":
     command     => "while ! (mongo --quiet --port ${port} --eval 'db.getMongo()'); do sleep 0.5; done",
     provider    => shell,
-    timeout     => 100,
+    timeout     => 300, # Might take long due to journal file preallocation
     refreshonly => true,
   }
 


### PR DESCRIPTION
Deploying `mongodb::core::mongod` to an EC2 machine fails due to a timeout:
```
    aws: Error: /Stage[main]/Mongodb::Role::Standalone/Mongodb::Core::Mongod[standalone]/Exec[wait for mongod_standalone up]: Failed to call refresh: Command exceeded timeout
    aws: Error: /Stage[main]/Mongodb::Role::Standalone/Mongodb::Core::Mongod[standalone]/Exec[wait for mongod_standalone up]: Command exceeded timeout
```

The log shows that preallocating journal files takes some time:
```
2015-07-23T10:01:08.680+0000 [initandlisten] preallocating a journal file /var/lib/mongodb/mongod_standalone/journal/prealloc.0
2015-07-23T10:01:11.887+0000 [initandlisten]            File Preallocator Progress: 975175680/1073741824        90%
2015-07-23T10:01:14.635+0000 [initandlisten]            File Preallocator Progress: 996147200/1073741824        92%
2015-07-23T10:01:18.343+0000 [initandlisten]            File Preallocator Progress: 1017118720/1073741824       94%
2015-07-23T10:01:22.187+0000 [initandlisten]            File Preallocator Progress: 1038090240/1073741824       96%
2015-07-23T10:01:26.043+0000 [initandlisten]            File Preallocator Progress: 1069547520/1073741824       99%
2015-07-23T10:02:13.053+0000 [initandlisten] preallocating a journal file /var/lib/mongodb/mongod_standalone/journal/prealloc.1
2015-07-23T10:02:16.447+0000 [initandlisten]            File Preallocator Progress: 912261120/1073741824        84%
2015-07-23T10:02:19.527+0000 [initandlisten]            File Preallocator Progress: 975175680/1073741824        90%
2015-07-23T10:02:22.079+0000 [initandlisten]            File Preallocator Progress: 1027604480/1073741824       95%
2015-07-23T10:03:09.230+0000 [initandlisten] preallocating a journal file /var/lib/mongodb/mongod_standalone/journal/prealloc.2
2015-07-23T10:03:09.437+0000 [signalProcessingThread] got signal 15 (Terminated), will terminate after current cmd ends
```