### PR TITLE
Allow configuration of relay SMTP servers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,16 +3,17 @@ GEM
   specs:
     CFPropertyList (2.2.8)
     diff-lcs (1.2.5)
-    facter (2.4.1)
+    facter (2.4.4)
       CFPropertyList (~> 2.2.6)
     hiera (1.3.4)
       json_pure
     json_pure (1.8.2)
-    multi_json (1.10.1)
+    multi_json (1.11.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
-    puppet (3.7.4)
+    net-telnet (0.1.1)
+    puppet (3.8.1)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
@@ -20,30 +21,33 @@ GEM
     puppet-syntax (1.4.1)
       rake
     rake (10.4.2)
-    rspec (3.2.0)
-      rspec-core (~> 3.2.0)
-      rspec-expectations (~> 3.2.0)
-      rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.0)
-      rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.0)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-its (1.1.0)
+      rspec-support (~> 3.3.0)
+    rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.2.0)
+    rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-support (3.2.1)
-    serverspec (2.8.2)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    serverspec (2.19.0)
       multi_json
       rspec (~> 3.0)
       rspec-its
-      specinfra (~> 2.12)
-    specinfra (2.12.6)
+      specinfra (~> 2.35)
+    sfl (2.2)
+    specinfra (2.37.6)
       net-scp
-      net-ssh
+      net-ssh (~> 2.7)
+      net-telnet
+      sfl
 
 PLATFORMS
   ruby
@@ -56,3 +60,6 @@ DEPENDENCIES
   rspec-core (~> 3.1)
   serverspec (~> 2.8)
   specinfra (~> 2.12)
+
+BUNDLED WITH
+   1.10.3

--- a/modules/postfix/spec/aliases/facts.json
+++ b/modules/postfix/spec/aliases/facts.json
@@ -1,0 +1,3 @@
+{
+  "domain": "localhost"
+}

--- a/modules/postfix/spec/aliases/manifest.pp
+++ b/modules/postfix/spec/aliases/manifest.pp
@@ -3,6 +3,7 @@ node default {
   user { ['foo', 'bar']:
     ensure     => present,
     system     => false,
+    managehome => true,
   }
 
   class { 'postfix':

--- a/modules/postfix/spec/aliases/manifest.pp
+++ b/modules/postfix/spec/aliases/manifest.pp
@@ -3,7 +3,6 @@ node default {
   user { ['foo', 'bar']:
     ensure     => present,
     system     => false,
-    managehome => true,
   }
 
   class { 'postfix':

--- a/modules/postfix/spec/aliases/manifest.pp
+++ b/modules/postfix/spec/aliases/manifest.pp
@@ -1,0 +1,22 @@
+node default {
+
+  user { ['foo', 'bar']:
+    ensure     => present,
+    system     => false,
+  }
+
+  class { 'postfix':
+    aliases => {
+      'foo'  => 'bar',
+    },
+  }
+
+  exec { "send mail to user foo":
+    provider    => shell,
+    command     => 'echo "test" | mail -s "Test" foo',
+    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    timeout     => 30,
+    user        => 'foo',
+    require     => [User ['foo', 'bar'], Class['postfix']],
+  }
+}

--- a/modules/postfix/spec/aliases/manifest.pp
+++ b/modules/postfix/spec/aliases/manifest.pp
@@ -11,7 +11,7 @@ node default {
     },
   }
 
-  exec { "send mail to user foo":
+  exec { 'send mail to user foo':
     provider    => shell,
     command     => 'echo "test" | mail -s "Test" foo',
     path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],

--- a/modules/postfix/spec/aliases/spec.rb
+++ b/modules/postfix/spec/aliases/spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'postfix' do
+
+  describe package('postfix') do
+    it { should be_installed }
+  end
+
+  describe service('postfix') do
+    it { should be_running }
+  end
+
+  describe file('/var/spool/mail/bar') do
+    it "is a file" do
+      expect(subject).to be_file
+    end
+    it "is a mail for foo forwarded to bar" do
+      expect(subject).to contain('To: foo@localhost')
+    end
+  end
+end

--- a/modules/postfix/spec/aliases/spec.rb
+++ b/modules/postfix/spec/aliases/spec.rb
@@ -10,12 +10,18 @@ describe 'postfix' do
     it { should be_running }
   end
 
+  describe command('timeout 10  bash  -c \'until (grep "status=sent" /var/log/mail.log);do sleep 1;done\'') do
+    it "postfix has correctly sent the test mail" do
+      expect(subject.exit_status).to eq 0
+    end
+  end
+
   describe file('/var/spool/mail/bar') do
-    it "is a file" do
+    it 'is a file' do
       expect(subject).to be_file
     end
-    it "is a mail for foo forwarded to bar" do
-      expect(subject).to contain('To: foo@localhost')
+    it 'is a mail for foo forwarded to bar' do
+      expect(subject).to contain('foo@localhost').after(/^To:/)
     end
   end
 end

--- a/modules/postfix/spec/filter/facts.json
+++ b/modules/postfix/spec/filter/facts.json
@@ -1,0 +1,3 @@
+{
+  "domain": "localhost"
+}

--- a/modules/postfix/spec/filter/manifest.pp
+++ b/modules/postfix/spec/filter/manifest.pp
@@ -1,0 +1,49 @@
+node default {
+
+  class { 'postfix':
+    transports => [
+      {
+        'filter'  => '/^To: filter_2525/',
+        'protocol' => 'smtp',
+        'host' => '127.0.0.1',
+        'port' => '2525',
+        'credentials' => 'foo:bar',
+      },
+      {
+        'filter'  => '/^To: filter_2828/',
+        'protocol' => 'smtp',
+        'host' => '127.0.1.1',
+        'port' => '2828',
+        'credentials' => 'bar:foo',
+      }
+    ],
+  }
+
+  exec { 'smtp-sink instance #1':
+    provider    => shell,
+    command     => '(sudo smtp-sink -vu postfix 127.0.0.1:2525 10 2>&1 | tee /tmp/2525)&',
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    require     => Class ['postfix'],
+  }
+
+  exec { 'smtp-sink instance #2':
+    provider    => shell,
+    command     => '(sudo smtp-sink -vu postfix 127.0.1.1:2828 10 2>&1 | tee /tmp/2828)&',
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    require     => Class ['postfix'],
+  }
+
+  exec { 'send test mail #1':
+    provider    => shell,
+    command     => 'echo "test" | mail -s "test" filter_2525@example.com',
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    require     => Exec ['smtp-sink instance #1'],
+  }
+
+  exec { 'send test mail #2':
+    provider    => shell,
+    command     => 'echo "test" | mail -s "test" filter_2828@example.com',
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    require     => Exec ['smtp-sink instance #2'],
+  }
+}

--- a/modules/postfix/spec/filter/spec.rb
+++ b/modules/postfix/spec/filter/spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'base64'
+
+describe 'postfix' do
+
+  describe package('postfix') do
+    it { should be_installed }
+  end
+
+  describe service('postfix') do
+    it { should be_running }
+  end
+
+  describe file('/etc/postfix/header_checks') do
+    it 'is a file' do
+      expect(subject).to be_file
+    end
+    it 'has a filter for filter_2525' do
+      expect(subject).to contain('filter_2525').after(/^\/\^To:/)
+    end
+  end
+
+  credentials1 = Base64.strict_encode64("\0foo\0bar")
+
+  describe file('/tmp/2525') do
+    it 'is a file' do
+      expect(subject).to be_file
+    end
+    it 'contains credentials foo:bar' do
+      expect(subject).to contain(credentials1).after(/AUTH PLAIN/)
+    end
+    it 'is a mail filtered correctly' do
+      expect(subject).to contain('<filter_2525@example.com>').after(/RCPT TO/)
+    end
+  end
+
+  credentials2 = Base64.strict_encode64("\0bar\0foo")
+
+  describe file('/tmp/2828') do
+    it 'is a file' do
+      expect(subject).to be_file
+    end
+    it 'contains credentials 2828_foo:2828_bar' do
+      expect(subject).to contain(credentials2).after(/AUTH PLAIN/)
+    end
+    it 'is a mail filtered correctly' do
+      expect(subject).to contain('<filter_2828@example.com>').after(/RCPT TO/)
+    end
+  end
+
+
+end

--- a/modules/postfix/spec/relay/facts.json
+++ b/modules/postfix/spec/relay/facts.json
@@ -1,0 +1,3 @@
+{
+  "domain": "localhost"
+}

--- a/modules/postfix/spec/relay/manifest.pp
+++ b/modules/postfix/spec/relay/manifest.pp
@@ -1,0 +1,34 @@
+node default {
+
+  class { 'postfix':
+    transports => [
+      {
+        'protocol' => 'smtp',
+        'host' => '127.0.1.1',
+        'port' => '2525',
+        'credentials' => 'foo:bar',
+      }
+    ],
+  }
+
+  exec { 'smtp-sink instance':
+    provider    => shell,
+    command     => '(sudo smtp-sink -vu postfix 127.0.1.1:2525 10 2>&1 | tee /tmp/2525)&',
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    require     => Class ['postfix'],
+  }
+
+  exec { 'send test mail #1':
+    provider    => shell,
+    command     => 'echo "test" | mail -s "test" filter_2525@example.com',
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    require     => Exec ['smtp-sink instance'],
+  }
+
+  exec { 'send test mail #2':
+    provider    => shell,
+      command     => 'echo "test" | mail -s "test" filter_2828@example.com',
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    require     => Exec ['smtp-sink instance'],
+  }
+}

--- a/modules/postfix/spec/relay/manifest.pp
+++ b/modules/postfix/spec/relay/manifest.pp
@@ -27,7 +27,7 @@ node default {
 
   exec { 'send test mail #2':
     provider    => shell,
-      command     => 'echo "test" | mail -s "test" filter_2828@example.com',
+    command     => 'echo "test" | mail -s "test" filter_2828@example.com',
     path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     require     => Exec ['smtp-sink instance'],
   }

--- a/modules/postfix/spec/relay/spec.rb
+++ b/modules/postfix/spec/relay/spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'base64'
+
+describe 'postfix' do
+
+  describe package('postfix') do
+    it { should be_installed }
+  end
+
+  describe service('postfix') do
+    it { should be_running }
+  end
+
+  describe file('/etc/postfix/header_checks') do
+    it 'is a file' do
+      expect(subject).to be_file
+    end
+    it 'contains a catch-all // regexp' do
+      expect(subject).to contain('//').before(/FILTER/)
+    end
+  end
+
+  credentials1 = Base64.strict_encode64("\0foo\0bar")
+
+  describe file('/tmp/2525') do
+    it 'is a file' do
+      expect(subject).to be_file
+    end
+    it 'contains credentials foo:bar' do
+      expect(subject).to contain(credentials1).after(/AUTH PLAIN/)
+    end
+    it 'is contains test mail #1' do
+      expect(subject).to contain('<filter_2525@example.com>').after(/RCPT TO/)
+    end
+    it 'is contains test mail #2' do
+      expect(subject).to contain('<filter_2828@example.com>').after(/RCPT TO/)
+    end
+  end
+end

--- a/modules/postfix/templates/header_checks
+++ b/modules/postfix/templates/header_checks
@@ -1,3 +1,4 @@
 <% @transports.each do |transport| -%>
+<% transport['filter'] = '//' if transport['filter'] == nil %>
 <%= transport['filter'] %> FILTER <%= transport['protocol'] %>:[<%= transport['host'] %>]:<%= transport['port'] %>
 <% end %>


### PR DESCRIPTION
Right now, we are able to relay to specific SMTP servers based on a pattern-matching mechanism applied to the mails headers. In some cases, a general (aka catch-all) mechanism is preferred.

As of now we can do: 
```puppet
  class { 'postfix':

    aliases    => {
      'root' => 'another@mail.com',
      'fuboo' => 'root'
    },

    transports => [
      {
        'filter' => '/^X-MDA: Amazon$/',
        'protocol' => 'smtp',
        'host' => 'mail.amazon.com',
        'port' => 'submission',
        'credentials' => 'foo:bar',
      }
    ]
  }
```

The `transports` list would create `/etc/postfix/header_checks` and `/etc/postfix/sasl_passwd` to correctly route mails based on the filter matched.

