### PR TITLE
Nginx: Enable SSL session cache

### DIFF
--- a/modules/nginx/templates/vhost/vhost_ssl_header.erb
+++ b/modules/nginx/templates/vhost/vhost_ssl_header.erb
@@ -7,7 +7,8 @@ server {
   ssl on;
   ssl_certificate      <%= @ssl_cert_file %>;
   ssl_certificate_key  <%= @ssl_key_file %>;
-  ssl_session_timeout  5m;
+  ssl_session_timeout  10m;
+  ssl_session_cache    shared:SSL:20m;
   ssl_prefer_server_ciphers   on;
 
 <% if @vhost_cfg_prepend -%><% @vhost_cfg_prepend.each do |option| -%>

--- a/spec/lib/vagrant_box.rb
+++ b/spec/lib/vagrant_box.rb
@@ -106,9 +106,15 @@ class VagrantBox
       puts command + (env.length > 0 ? ' (' + env.to_s + ')' : '')
     end
 
+    # Reset bundler/rubygems environment, so that `vagrant` uses its own ruby environment
+    env_original = ENV.to_hash
+    %w[BUNDLE_APP_CONFIG BUNDLE_CONFIG BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYLIB RUBYOPT GEMRC GEM_PATH].each do |var|
+      env_original[var] = nil
+    end
+
     output_stdout = output_stderr = exit_code = nil
     Dir.chdir(@working_dir.to_s) {
-      Open3.popen3(ENV.to_hash.merge(env), command) { |stdin, stdout, stderr, wait_thr|
+      Open3.popen3(env_original.merge(env), command) { |stdin, stdout, stderr, wait_thr|
         output_stdout = stdout.read.chomp
         output_stderr = stderr.read.chomp
         exit_code = wait_thr.value


### PR DESCRIPTION
Seems to improve performance additionally to http keep-alive.
```
ssl_session_cache shared:SSL:10m;
ssl_session_timeout  10m;
```

See http://nginx.org/en/docs/http/configuring_https_servers.html