### PR TITLE
Gearman: PHP client fails to connect when listening on "0.0.0.0"

### DIFF
--- a/modules/gearman/manifests/server.pp
+++ b/modules/gearman/manifests/server.pp
@@ -6,7 +6,7 @@ class gearman::server(
   $mysql_password = 'gearman',
   $mysql_db = 'gearman',
   $mysql_table = 'gearman_queue',
-  $bind_ip = '',
+  $bind_ip = undef,
   $jobretries = 25,
 ) {
 

--- a/modules/gearman/manifests/server.pp
+++ b/modules/gearman/manifests/server.pp
@@ -6,7 +6,7 @@ class gearman::server(
   $mysql_password = 'gearman',
   $mysql_db = 'gearman',
   $mysql_table = 'gearman_queue',
-  $bind_ip = '0.0.0.0',
+  $bind_ip = '',
   $jobretries = 25,
 ) {
 

--- a/modules/gearman/templates/default
+++ b/modules/gearman/templates/default
@@ -16,4 +16,4 @@
 # Missing examples for memcache persitent queue store...
 
 # Parameters to pass to gearmand.
-PARAMS="--listen=<%= @bind_ip %> <% @daemon_args.each do |arg| -%><%= arg -%> <% end %>--job-retries=<%= @jobretries %>"
+PARAMS="<% if @bind_ip and not @bind_ip.empty? %>--listen=<%= @bind_ip %><% end %> <% @daemon_args.each do |arg| -%><%= arg -%> <% end %>--job-retries=<%= @jobretries %>"


### PR DESCRIPTION
Listening on 0.0.0.0 was introduced here: #934

Unfortunately with this setting the Gearman php extension can't connect to the server any more (it halts at `GearmanClient::addServer()`.

@kris-lab can you investigate - what the correct setting is? Both on the server and the client?
This is currently affecting developer VMs.

cc @christopheschwyzer 