### PR TITLE
Capistrano install fails

### DIFF
--- a/modules/capistrano/manifests/init.pp
+++ b/modules/capistrano/manifests/init.pp
@@ -1,5 +1,10 @@
 class capistrano {
 
+  ruby::gem { 'net-ssh':
+    ensure => '~>2.8',
+  }
+  ->
+
   ruby::gem { 'capistrano':
     ensure => present,
   }

--- a/modules/capistrano/spec/default/manifest.pp
+++ b/modules/capistrano/spec/default/manifest.pp
@@ -1,0 +1,6 @@
+node default {
+
+  class { 'capistrano':
+  }
+
+}

--- a/modules/capistrano/spec/default/spec.rb
+++ b/modules/capistrano/spec/default/spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'capistrano' do
+
+  describe command('gem list') do
+    its(:stdout) { should match 'capistrano' }
+  end
+end

--- a/modules/capistrano/spec/default/spec.rb
+++ b/modules/capistrano/spec/default/spec.rb
@@ -5,4 +5,9 @@ describe 'capistrano' do
   describe command('gem list') do
     its(:stdout) { should match 'capistrano' }
   end
+
+  describe command('cap --version') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match 'Capistrano' }
+  end
 end


### PR DESCRIPTION
Looks like some Gem dependency problem.
Also we should add a spec for "capistrano" itself.

```
       [1;31mError: Execution of '/usr/bin/gem install --no-rdoc --no-ri capistrano' returned 1: ERROR:  Error installing capistrano:
       	net-ssh requires Ruby version >= 2.0.[0m
       [1;31mError: /Stage[main]/Capistrano/Ruby::Gem[capistrano]/Package[capistrano]/ensure: change from absent to present failed: Execution of '/usr/bin/gem install --no-rdoc --no-ri capistrano' returned 1: ERROR:  Error installing capistrano:
       	net-ssh requires Ruby version >= 2.0.[0m
       [1;31mWarning: /Package[pulsar]: Skipping because of failed dependencies[0m
       [mNotice: Finished catalog run in 6.34 seconds[0m
```