### PR TITLE
Spec fails: network::nat

### DIFF
--- a/modules/network/spec/nat/spec.rb
+++ b/modules/network/spec/nat/spec.rb
@@ -6,7 +6,7 @@ describe 'network::nat' do
     it { should be_installed }
   end
 
-  describe file('/proc/sys/net/ipv4/ip_forward ') do
+  describe file('/proc/sys/net/ipv4/ip_forward') do
     its(:content) { should match /1/ }
   end
 


### PR DESCRIPTION
```
Notice: /Stage[main]/Network::Nat/Sysctl::Entry[ip4_forward]/File[/etc/sysctl.d/ip4_forward]/ensure: defined content as '{md5}b2468e0a80b778fa10b6e3929e81f143'

Notice: /Stage[main]/Network::Nat/Iptables::Entry[Set up NAT]/Exec[Set up NAT]/returns: executed successfully
Notice: /Stage[main]/Network::Nat/Iptables::Entry[Allow inbound traffic for established connection]/Exec[Allow inbound traffic for established connection]/returns: executed successfully
Notice: /Stage[main]/Network::Nat/Sysctl::Entry[ip4_forward]/Exec[/sbin/sysctl -p /etc/sysctl.d/ip4_forward]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Network::Nat/Iptables::Entry[Allow outbound traffic]/Exec[Allow outbound traffic]/returns: executed successfully
Notice: Finished catalog run in 0.21 seconds

.F...

Failures:

  1) network::nat File "/proc/sys/net/ipv4/ip_forward " content should match /1/
     Failure/Error: its(:content) { should match /1/ }
       expected "" to match /1/
       Diff:
       @@ -1,2 +1,2 @@
       -/1/
       +""
     # ./modules/network/spec/nat/spec.rb:10:in `block (3 levels) in <top (required)>'

Finished in 1 minute 31.66 seconds (files took 0.23935 seconds to load)
5 examples, 1 failure

Failed examples:
```
@ppp0 @kris-lab can you look into this?
