### PR TITLE
cm::reverse_proxy: Forward original IP to application

### DIFF
--- a/modules/cm/manifests/reverse_proxy.pp
+++ b/modules/cm/manifests/reverse_proxy.pp
@@ -61,6 +61,7 @@ define cm::reverse_proxy(
       location_cfg_append => [
         "proxy_set_header Host '${upstream_opts[header_host]}';",
         'proxy_set_header X-Real-IP $remote_addr;',
+        'proxy_set_header X-Forwarded-For $remote_addr;',
         "proxy_pass ${proto}://${upstream_name_real};",
         'proxy_next_upstream error timeout http_502;'
       ]

--- a/modules/cm/manifests/reverse_proxy.pp
+++ b/modules/cm/manifests/reverse_proxy.pp
@@ -61,7 +61,6 @@ define cm::reverse_proxy(
       location_cfg_append => [
         "proxy_set_header Host '${upstream_opts[header_host]}';",
         'proxy_set_header X-Real-IP $remote_addr;',
-        'proxy_set_header X-Forwarded-For $remote_addr;',
         "proxy_pass ${proto}://${upstream_name_real};",
         'proxy_next_upstream error timeout http_502;'
       ]

--- a/modules/cm/manifests/vhost.pp
+++ b/modules/cm/manifests/vhost.pp
@@ -61,6 +61,11 @@ define cm::vhost(
     ssl_key             => $ssl_key,
     location_cfg_append => [
       'include fastcgi_params;',
+      'set $_real_client_ip $remote_addr;',
+      'if ($http_x_real_ip != "") {',
+      '  set $_real_client_ip $http_x_real_ip;',
+      '}',
+      'fastcgi_param REMOTE_ADDR $_real_client_ip;',
       "fastcgi_param SCRIPT_FILENAME ${path}/public/index.php;",
       "fastcgi_param CM_DEBUG ${debug_int};",
       'fastcgi_keep_conn on;',
@@ -109,6 +114,11 @@ define cm::vhost(
       'gzip_types application/x-javascript text/css text/plain application/xml image/svg+xml;',
 
       'include fastcgi_params;',
+      'set $_real_client_ip $remote_addr;',
+      'if ($http_x_real_ip != "") {',
+      '  set $_real_client_ip $http_x_real_ip;',
+      '}',
+      'fastcgi_param REMOTE_ADDR $_real_client_ip;',
       "fastcgi_param SCRIPT_FILENAME ${path}/public/index.php;",
       "fastcgi_param CM_DEBUG ${debug_int};",
       'fastcgi_keep_conn on;',

--- a/modules/cm/spec/vhost/custom-upstream/manifest.pp
+++ b/modules/cm/spec/vhost/custom-upstream/manifest.pp
@@ -54,6 +54,17 @@ inZL8VyT42eLzq/N4eyQ/Xxd7HR0gWmwu+o18FYcrZVbaF3+VyQ=
   $domain_cm = 'foo.cm'
   $domain_xx = 'foo.xx'
 
+  exec { 'mock-second-ip-address':
+    command   => 'ifconfig eth0:0 192.168.199.199',
+    path      => ['/bin', '/sbin'],
+  }
+  ->
+  exec { 'netcat listening socket on 9001':
+    command   => 'nc -l -p 9001 >/var/log/spec_nc_log  &',
+    path      => ['/bin', '/sbin'],
+  }
+  ->
+
   host { 'mock-domain-resolution':
     host_aliases => [
       $domain_cm, "www.${domain_cm}", "admin.${domain_cm}",
@@ -61,9 +72,10 @@ inZL8VyT42eLzq/N4eyQ/Xxd7HR0gWmwu+o18FYcrZVbaF3+VyQ=
       'bar.cm', 'bor.cm', 'baz.cm' ],
     ip           => '127.0.0.1',
   }
+  ->
 
   cm::upstream::fastcgi { 'foo':
-    members => [ 'localhost:9000', 'localhost:9001'],
+    members => [ 'localhost:9001'],
   }
 
   cm::vhost { $domain_xx:
@@ -88,5 +100,4 @@ inZL8VyT42eLzq/N4eyQ/Xxd7HR0gWmwu+o18FYcrZVbaF3+VyQ=
       members => [ 'localhost:8888', 'localhost:8889'],
     }
   }
-
 }

--- a/modules/cm/spec/vhost/custom-upstream/spec.rb
+++ b/modules/cm/spec/vhost/custom-upstream/spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 describe 'cm::vhost' do
+  describe file ('/etc/nginx/conf.d/foo-upstream.conf') do
+    it { should be_file }
+    its(:content) { should match /server localhost:9001/ }
+  end
+
+  describe file ('/etc/nginx/conf.d/fastcgi-backend-upstream.conf') do
+    it { should be_file }
+    its(:content) { should match /server localhost:8888/ }
+    its(:content) { should match /server localhost:8889/ }
+  end
+
   redirect_location = /< Location: https:\/\/www\.foo\.cm\//
 
   ['bar', 'bor', 'baz'].each do |name|
@@ -9,23 +20,20 @@ describe 'cm::vhost' do
     end
   end
 
+  describe 'Checking if REMOTE_ADDR fcgi header is set to real ip address' do
+    describe command("curl --proxy '' --interface eth0:0 -m 1 -kL https://foo.xx") do
+    end
+    describe file ('/var/log/spec_nc_log') do
+      its(:content) { should match /REMOTE_ADDR192.168.199.199/ }
+    end
+
+  end
+
   ['www.', 'admin.', ''].each do |name|
     ['xx', 'cm'].each do |tld|
       describe command("curl --proxy '' -v http://#{name}foo.#{tld}") do
         its(:stderr) { should match /< Location: https:\/\/#{name}foo\.#{tld}\// }
       end
     end
-  end
-
-  describe file ('/etc/nginx/conf.d/foo-upstream.conf') do
-    it { should be_file }
-    its(:content) { should match /server localhost:9000/ }
-    its(:content) { should match /server localhost:9001/ }
-  end
-
-  describe file ('/etc/nginx/conf.d/fastcgi-backend-upstream.conf') do
-    it { should be_file }
-    its(:content) { should match /server localhost:8888/ }
-    its(:content) { should match /server localhost:8889/ }
   end
 end


### PR DESCRIPTION
Part of https://github.com/cargomedia/puppet-cargomedia/issues/887
cc @ppp0 

See https://rtcamp.com/tutorials/nginx/forwarding-visitors-real-ip/

We set headers like `X-Real-IP` already in some modules.