### PR TITLE
Janus transport class duplicate declaration

### DIFF
--- a/modules/janus/manifests/init.pp
+++ b/modules/janus/manifests/init.pp
@@ -25,9 +25,6 @@ class janus (
   require 'janus::deps::libusrsctp'
   require 'janus::deps::libwebsockets'
 
-  include 'janus::transport::http'
-  include 'janus::transport::websockets'
-
   user { 'janus':
     ensure => present,
     system => true,

--- a/modules/janus/manifests/init.pp
+++ b/modules/janus/manifests/init.pp
@@ -25,6 +25,9 @@ class janus (
   require 'janus::deps::libusrsctp'
   require 'janus::deps::libwebsockets'
 
+  include 'janus::transport::http'
+  include 'janus::transport::websockets'
+
   user { 'janus':
     ensure => present,
     system => true,

--- a/modules/janus/manifests/init.pp
+++ b/modules/janus/manifests/init.pp
@@ -92,5 +92,4 @@ class janus (
     content           => template("${module_name}/init.sh"),
     require           => [User['janus']],
   }
-
 }

--- a/modules/janus/manifests/init.pp
+++ b/modules/janus/manifests/init.pp
@@ -92,4 +92,5 @@ class janus (
     content           => template("${module_name}/init.sh"),
     require           => [User['janus']],
   }
+
 }

--- a/modules/janus/manifests/service.pp
+++ b/modules/janus/manifests/service.pp
@@ -3,8 +3,10 @@ class janus::service {
   require 'janus'
 
   service { 'janus':
+    ensure => running,
     hasrestart => true,
-    enable => true,
+    enable     => true,
+    require    => [ Helper::Script['install janus'], Sysvinit::Script['janus'] ],
   }
 
   @monit::entry { 'janus':

--- a/modules/janus/manifests/transport.pp
+++ b/modules/janus/manifests/transport.pp
@@ -1,0 +1,6 @@
+define janus::transport {
+
+  include 'janus::service'
+  include 'janus'
+
+}

--- a/modules/janus/manifests/transport/http.pp
+++ b/modules/janus/manifests/transport/http.pp
@@ -15,7 +15,6 @@ class janus::transport::http(
   $admin_acl = '127.,192.168.0.'
 ) {
 
-  require 'janus'
   include 'janus::service'
 
   file { '/etc/janus/janus.transport.http.cfg':

--- a/modules/janus/manifests/transport/http.pp
+++ b/modules/janus/manifests/transport/http.pp
@@ -15,8 +15,6 @@ class janus::transport::http(
   $admin_acl = '127.,192.168.0.'
 ) {
 
-  include 'janus::service'
-
   file { '/etc/janus/janus.transport.http.cfg':
     ensure    => 'present',
     content   => template("${module_name}/transport/http.cfg"),
@@ -25,5 +23,7 @@ class janus::transport::http(
     mode      => '0644',
     notify => Service['janus'],
   }
+  ->
 
+  janus::transport { $name: }
 }

--- a/modules/janus/manifests/transport/websockets.pp
+++ b/modules/janus/manifests/transport/websockets.pp
@@ -12,7 +12,6 @@ class janus::transport::websockets(
   $admin_ws_acl = '127.,192.168.',
 ) {
 
-  require 'janus'
   include 'janus::service'
 
   file { '/etc/janus/janus.transport.websockets.cfg':

--- a/modules/janus/manifests/transport/websockets.pp
+++ b/modules/janus/manifests/transport/websockets.pp
@@ -12,8 +12,6 @@ class janus::transport::websockets(
   $admin_ws_acl = '127.,192.168.',
 ) {
 
-  include 'janus::service'
-
   file { '/etc/janus/janus.transport.websockets.cfg':
     ensure    => 'present',
     content   => template("${module_name}/transport/websockets.cfg"),
@@ -22,5 +20,8 @@ class janus::transport::websockets(
     mode      => '0644',
     notify    => Service['janus'],
   }
+  ->
+
+  janus::transport { $name: }
 
 }

--- a/modules/janus/spec/transport/manifest.pp
+++ b/modules/janus/spec/transport/manifest.pp
@@ -1,0 +1,10 @@
+node default {
+
+  class { 'janus::transport::http':
+    port => 1337,
+  }
+
+  class { 'janus::transport::websockets':
+    ws_port => 7017,
+  }
+}

--- a/modules/janus/spec/transport/spec.rb
+++ b/modules/janus/spec/transport/spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'janus::plugins' do
+
+  describe file('/etc/janus/janus.transport.http.cfg') do
+    it { should be_file }
+  end
+
+  describe file('/etc/janus/janus.transport.websockets.cfg') do
+    it { should be_file }
+  end
+
+  describe port (7017) do
+    it {should be_listening}
+  end
+
+  describe port (1337) do
+    it {should be_listening}
+  end
+
+end


### PR DESCRIPTION
`Duplicate declaration: Class[Janus::Transport::Http] is already declared; cannot redeclare` etc.

same for `Janus::Transport::Websockets`

