### PR TITLE
janus modules: adjust "unless" to consider version

### DIFF
--- a/modules/janus/manifests/deps/libsrtp.pp
+++ b/modules/janus/manifests/deps/libsrtp.pp
@@ -1,5 +1,5 @@
 class janus::deps::libsrtp(
-  $version = '1.5.0',
+  $version,
 ) {
 
   require 'build::pkg_config'

--- a/modules/janus/manifests/deps/libusrsctp.pp
+++ b/modules/janus/manifests/deps/libusrsctp.pp
@@ -1,12 +1,21 @@
-class janus::deps::libusrsctp {
+class janus::deps::libusrsctp(
+  $version,
+) {
 
   require 'git'
   require 'build::libtool'
   require 'build::automake'
 
+  git::repository { 'usrsctp':
+    remote      => 'https://github.com/sctplab/usrsctp',
+    directory   => '/opt/src/janus-plugins/usrsctp',
+    revision    => $version,
+  }
+  ~>
+
   helper::script { 'install libusrsctp':
     content => template("${module_name}/deps/libusrsctp_install.sh"),
-    unless  => 'ldconfig -v 2>/dev/null | grep -qE "libusrsctp\."',
+    refresh_only => true,
     timeout => 900,
   }
 }

--- a/modules/janus/manifests/deps/libwebsockets.pp
+++ b/modules/janus/manifests/deps/libwebsockets.pp
@@ -1,5 +1,6 @@
 class janus::deps::libwebsockets(
-  $version = '1.5',
+  $version,
+  $version_file_name,
 ) {
 
   require 'git'

--- a/modules/janus/manifests/plugin.pp
+++ b/modules/janus/manifests/plugin.pp
@@ -5,7 +5,14 @@ define janus::plugin {
   include 'janus::service'
   include 'janus'
 
-  $janus_version = $janus::version::number
+  $janus_version = $janus::version::main
+
+  git::repository { 'janus-gateway':
+    remote      => 'https://github.com/meetecho/janus-gateway.git',
+    directory   => '/opt/src/janus',
+    revision    => $janus::version::main,
+  }
+  ~>
 
   helper::script { "install janus plugin ${name}":
     content => template("${module_name}/plugin_install.sh"),

--- a/modules/janus/manifests/version.pp
+++ b/modules/janus/manifests/version.pp
@@ -1,1 +1,7 @@
-class janus::version($number = 'b5865bdd56569ae660bf945323705010ae55d7fc') { }
+class janus::version(
+  $main = 'b5865bdd56569ae660bf945323705010ae55d7fc',
+  $srtp = 'v.1.5.0',
+  $usrsctp = '37399f6e86d407eef56ea170f9e0da554bd120ee',
+  $websockets = '1.5',
+  $websockets_version_filename = 'libwebsockets-1.5-chrome47-firefox41',
+) { }

--- a/modules/janus/templates/deps/libusrsctp_install.sh
+++ b/modules/janus/templates/deps/libusrsctp_install.sh
@@ -1,8 +1,6 @@
 #!/bin/sh -e
 
-rm -rf usrsctp
-git clone https://github.com/sctplab/usrsctp
-cd usrsctp
+cd /opt/src/janus-plugins/usrsctp
 ./bootstrap
 ./configure --prefix=/usr
 make

--- a/modules/janus/templates/deps/libwebsockets_install.sh
+++ b/modules/janus/templates/deps/libwebsockets_install.sh
@@ -1,9 +1,8 @@
 #!/bin/sh -e
 
-rm -rf libwebsocket
-wget http://git.libwebsockets.org/cgi-bin/cgit/libwebsockets/snapshot/libwebsockets-1.5-chrome47-firefox41.tar.gz
-tar -xzf libwebsockets-1.5-chrome47-firefox41.tar.gz
-cd libwebsockets-1.5-chrome47-firefox41
+wget http://git.libwebsockets.org/cgi-bin/cgit/libwebsockets/snapshot/<%= @version_file_name %>.tar.gz
+tar -xzf <%= @version_file_name %>.tar.gz
+cd <%= @version_file_name %>
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..

--- a/modules/janus/templates/install.sh
+++ b/modules/janus/templates/install.sh
@@ -3,13 +3,10 @@
 DISABLE="--disable-docs --disable-rabbitmq --disable-plugin-audiobridge --disable-plugin-recordplay --disable-plugin-sip"
 DISABLE="${DISABLE} --disable-plugin-streaming --disable-plugin-videocall --disable-plugin-videoroom --disable-plugin-voicemail"
 
-rm -rf janus-gateway /opt/janus
-git clone https://github.com/meetecho/janus-gateway.git
-cd janus-gateway
-git checkout <%= @version %>
+cd /opt/src/janus
 ./autogen.sh
 ./configure --prefix=/opt/janus $DISABLE --enable-post-processing --enable-plugin-echotest
 make
 make install
-mv /opt/janus/bin/janus /usr/bin
-mv /opt/janus/etc/janus/* /etc/janus
+mv -f /opt/janus/bin/janus /usr/bin
+mv -bn /opt/janus/etc/janus/* /etc/janus


### PR DESCRIPTION
Janus and janus plugins are installed from git sources. We install a specific sha, but don't check it in the `unless`.

Idea: Use git::repository (https://github.com/cargomedia/puppet-packages/pull/1003)

Maybe extract that into a `git::checkout` resource or similar?
cc @tomaszdurka 