### PR TITLE
Add module to blacklist kernel modules

### DIFF
--- a/modules/kernel/manifests/modprobe.pp
+++ b/modules/kernel/manifests/modprobe.pp
@@ -1,0 +1,13 @@
+define kernel::modprobe(
+  $content
+) {
+
+  file { "/etc/modprobe.d/${title}.conf":
+    ensure  => file,
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+    content => $content
+  }
+
+}

--- a/modules/kernel/manifests/modprobe_blacklist.pp
+++ b/modules/kernel/manifests/modprobe_blacklist.pp
@@ -1,0 +1,8 @@
+define kernel::modprobe_blacklist(
+  $modules
+) {
+
+  kernel::modprobe{ "blacklist-${title}":
+    content => template("${module_name}/modprobe_blacklist.erb")
+  }
+}

--- a/modules/kernel/manifests/modprobe_blacklist.pp
+++ b/modules/kernel/manifests/modprobe_blacklist.pp
@@ -5,4 +5,10 @@ define kernel::modprobe_blacklist(
   kernel::modprobe{ "blacklist-${title}":
     content => template("${module_name}/modprobe_blacklist.erb")
   }
+
+  exec { "unload modules for blacklist ${title}":
+    path     => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    provider => shell,
+    command  => template("${module_name}/unload_modules.sh.erb"),
+  }
 }

--- a/modules/kernel/spec/modprobe_blacklist/manifest.pp
+++ b/modules/kernel/spec/modprobe_blacklist/manifest.pp
@@ -1,0 +1,11 @@
+node default {
+
+  kernel::modprobe_blacklist {'foo':
+    modules => ['foo1', 'foo2'],
+  }
+
+  kernel::modprobe_blacklist {'bar':
+    modules => ['bar1'],
+  }
+
+}

--- a/modules/kernel/spec/modprobe_blacklist/manifest.pp
+++ b/modules/kernel/spec/modprobe_blacklist/manifest.pp
@@ -1,11 +1,13 @@
 node default {
 
-  kernel::modprobe_blacklist {'foo':
-    modules => ['foo1', 'foo2'],
+  exec { '/sbin/modprobe blowfish_common': }
+  ->
+  kernel::modprobe_blacklist { 'blowfish_common':
+    modules => ['blowfish_common'],
   }
 
-  kernel::modprobe_blacklist {'bar':
-    modules => ['bar1'],
+  kernel::modprobe_blacklist { 'foo':
+    modules => ['foo1', 'foo2'],
   }
 
 }

--- a/modules/kernel/spec/modprobe_blacklist/spec.rb
+++ b/modules/kernel/spec/modprobe_blacklist/spec.rb
@@ -3,9 +3,13 @@ require 'spec_helper'
 describe 'kernel::modprobe_blacklist' do
 
   describe command('modprobe --showconfig') do
+    its(:stdout) { should match "blacklist blowfish_common\n" }
     its(:stdout) { should match "blacklist foo1\n" }
     its(:stdout) { should match "blacklist foo2\n" }
-    its(:stdout) { should match "blacklist bar1\n" }
+  end
+
+  describe kernel_module('blowfish_common') do
+    it { should_not be_loaded }
   end
 
 end

--- a/modules/kernel/spec/modprobe_blacklist/spec.rb
+++ b/modules/kernel/spec/modprobe_blacklist/spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'kernel::modprobe_blacklist' do
+
+  describe command('modprobe --showconfig') do
+    its(:stdout) { should match "blacklist foo1\n" }
+    its(:stdout) { should match "blacklist foo2\n" }
+    its(:stdout) { should match "blacklist bar1\n" }
+  end
+
+end

--- a/modules/kernel/templates/modprobe_blacklist.erb
+++ b/modules/kernel/templates/modprobe_blacklist.erb
@@ -1,0 +1,3 @@
+<% @modules.each do |mod| -%>
+blacklist <%= mod %>
+<% end %>

--- a/modules/kernel/templates/unload_modules.sh.erb
+++ b/modules/kernel/templates/unload_modules.sh.erb
@@ -1,0 +1,3 @@
+<% @modules.each do |mod| -%>
+if (modinfo "<%= mod %>"); then modprobe --remove "<%= mod %>"; fi
+<% end %>


### PR DESCRIPTION
Add a file to `/etc/modprobe.d/`, which contains 1 or more lines of:
```
blacklist <module name>
```