### PR TITLE
Specifically run logrotate as root

### DIFF
--- a/modules/logrotate/spec/default/spec.rb
+++ b/modules/logrotate/spec/default/spec.rb
@@ -6,8 +6,8 @@ describe 'logrotate' do
     it { should be_installed }
   end
 
-  describe file('/etc/cron.daily/logrotate') do
-    it { should be_file }
-    it { should be_executable }
+  describe command('/etc/cron.daily/logrotate') do
+    its(:exit_status) { should eq 0 }
   end
+
 end

--- a/modules/logrotate/templates/logrotate.conf
+++ b/modules/logrotate/templates/logrotate.conf
@@ -2,6 +2,9 @@
 # rotate log files weekly
 weekly
 
+# Run as root
+su root
+
 # keep 4 weeks worth of backlogs
 rotate 4
 


### PR DESCRIPTION
@ppp0 please review

Currently logrotate fails on ubuntu, because log files have the group "syslog" (which doesn't exist on debian).
Enforcing using "root" seems to solve the problem.