### PR TITLE
Nvidia: error log parser

### DIFF
--- a/modules/nvidia/manifests/init.pp
+++ b/modules/nvidia/manifests/init.pp
@@ -1,0 +1,14 @@
+class nvidia {
+
+  @bipbip::entry { 'logparser-nvidia-gpu':
+    plugin  => 'log-parser',
+    options => {
+      'metric_group' => 'nvidia-gpu',
+      'path' => '/var/log/syslog',
+      'matchers' => [
+        { 'name' => 'nvrm::xid',
+          'regexp' => 'NVRM: Xid' }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Related to driver: https://github.com/cargomedia/puppet-packages/issues/973

Add a bipbip log parser for "NVRM: Xid" in the syslog.
Docu: http://docs.nvidia.com/deploy/xid-errors/
Example:
```
2016-01-02T10:49:30.895506+00:00 bulldog3 kernel: [150123.886811] NVRM: Xid (PCI:0000:0a:00): 31, Ch 00000008, engmask 00000101, intr 10000000
```

@kris-lab could you add it? Can be without driver installation (https://github.com/cargomedia/puppet-packages/issues/973) yet, just adding the module, so we can add the log parser?