### PR TITLE
UFW - Fix order of exec for ssh and service recognition

### DIFF
--- a/modules/ssh/manifests/init.pp
+++ b/modules/ssh/manifests/init.pp
@@ -24,7 +24,7 @@ class ssh (
     notify  => Service['ssh'],
   }
 
-# Workaround for http://projects.puppetlabs.com/issues/2014
+  # Workaround for http://projects.puppetlabs.com/issues/2014
   file { '/etc/ssh/ssh_known_hosts':
     ensure => file,
     owner  => 'root',
@@ -44,6 +44,7 @@ class ssh (
   }
 
   @ufw::application { 'OpenSSH':
-    app_ports => "${port}/tcp"
+    app_ports => "${port}/tcp",
+    before    => Exec['Activate ufw'],
   }
 }

--- a/modules/ssh/manifests/init.pp
+++ b/modules/ssh/manifests/init.pp
@@ -45,6 +45,5 @@ class ssh (
 
   @ufw::application { 'OpenSSH':
     app_ports => "${port}/tcp",
-    before    => Exec['Activate ufw'],
   }
 }

--- a/modules/ufw/Puppetfile
+++ b/modules/ufw/Puppetfile
@@ -1,7 +1,3 @@
 mod 'cargomedia/apt',
    :git => 'git@github.com:cargomedia/puppet-packages.git',
    :path => 'modules/apt'
-
-mod 'cargomedia/daemon',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
-   :path => 'modules/daemon'

--- a/modules/ufw/Puppetfile
+++ b/modules/ufw/Puppetfile
@@ -1,3 +1,7 @@
 mod 'cargomedia/apt',
    :git => 'git@github.com:cargomedia/puppet-packages.git',
    :path => 'modules/apt'
+
+mod 'cargomedia/daemon',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/daemon'

--- a/modules/ufw/manifests/init.pp
+++ b/modules/ufw/manifests/init.pp
@@ -17,6 +17,6 @@ class ufw {
     recurse => true,
   }
 
-  Ufw::Application <| |>
-  Ufw::Rule <| |>
+  Ufw::Application <| |> -> Exec['Activate ufw']
+  Ufw::Rule <| |> -> Exec['Activate ufw']
 }

--- a/modules/ufw/manifests/service.pp
+++ b/modules/ufw/manifests/service.pp
@@ -11,6 +11,7 @@ class ufw::service {
   ->
 
   service {'ufw':
+    provider => $::service_provider, # Workaround for https://github.com/cargomedia/puppet-packages/issues/1071
     enable => true,
     hasrestart => true,
     hasstatus => true,

--- a/modules/ufw/manifests/service.pp
+++ b/modules/ufw/manifests/service.pp
@@ -10,10 +10,9 @@ class ufw::service {
   }
   ->
 
-  service {'ufw':
-    provider => $::service_provider, # Workaround for https://github.com/cargomedia/puppet-packages/issues/1071
-    enable => true,
+  service { 'ufw':
+    enable     => true,
     hasrestart => true,
-    hasstatus => true,
+    hasstatus  => true,
   }
 }

--- a/modules/ufw/spec/app-profile-virtual/manifest.pp
+++ b/modules/ufw/spec/app-profile-virtual/manifest.pp
@@ -6,5 +6,6 @@ node default {
     app_ports       => '21,23:25/tcp|10000:15000/udp',
   }
 
+  include 'ssh'
   include 'ufw'
 }

--- a/modules/ufw/spec/app-profile-virtual/spec.rb
+++ b/modules/ufw/spec/app-profile-virtual/spec.rb
@@ -7,6 +7,11 @@ describe 'ufw::app-profile' do
     its(:stdout) { should match /10000:15000\/udp/ }
   }
 
+  describe command('ufw status') {
+    its(:stdout) { should match /active/ }
+    its(:stdout) { should match /OpenSSH/ }
+  }
+
   describe iptables do
     it { should have_rule('-m multiport --dports 10000:15000').with_table('filter').with_chain('ufw-user-input') }
   end


### PR DESCRIPTION
* Fix Service provider (bug https://github.com/cargomedia/puppet-packages/issues/1071) - otherwise puppet won't be able to properly get `ufw`'s status
* Add before clause to https://github.com/cargomedia/puppet-packages/blob/master/modules/ssh/manifests/init.pp#L46 to make sure the rule is there *before* the firewall gets activated