### PR TITLE
Coturn spec failed

### DIFF
--- a/modules/coturn/spec/coturn-firewalled/manifest.pp
+++ b/modules/coturn/spec/coturn-firewalled/manifest.pp
@@ -9,9 +9,6 @@ node default {
     realm => 'mydomain.com',
   }
 
+  include 'ssh'
   include 'ufw'
-
-  ufw::rule { 'ssh':
-    app_or_port => 'OpenSSH',
-  }
 }

--- a/modules/coturn/spec/default/spec.rb
+++ b/modules/coturn/spec/default/spec.rb
@@ -22,11 +22,16 @@ describe 'coturn' do
     its(:content) { should match /^realm=mydomain.com$/ }
   end
 
+  # Wait for coturn to start up
+  describe command('timeout --signal=9 30 bash -c "while ! (curl -s http://localhost:3478/ | grep -q \"TURN Server\"); do sleep 0.5; done"') do
+    its(:exit_status) { should eq 0 }
+  end
+
   describe command('turnutils_uclient -u super -w supper-bad-pass -m 1 -n 1 -M -B -z 1 127.0.0.1') do
     its(:stdout) { should match /0: ERROR: Cannot complete Allocation/ }
   end
 
-  describe command('timeout 2 turnutils_uclient -u super -w super -m 1 -n 1 -M -B -z 1 127.0.0.1') do
+  describe command('turnutils_uclient -u super -w super -m 1 -n 1 -M -B -z 1 127.0.0.1') do
     its(:stdout) { should match /1: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0/ }
   end
 

--- a/modules/coturn/spec/default/spec.rb
+++ b/modules/coturn/spec/default/spec.rb
@@ -22,17 +22,12 @@ describe 'coturn' do
     its(:content) { should match /^realm=mydomain.com$/ }
   end
 
-  # Wait for coturn to start up
-  describe command('timeout --signal=9 30 bash -c "while ! (curl -s http://localhost:3478/ | grep -q \"TURN Server\"); do sleep 0.5; done"') do
-    its(:exit_status) { should eq 0 }
-  end
-
   describe command('turnutils_uclient -u super -w supper-bad-pass -m 1 -n 1 -M -B -z 1 127.0.0.1') do
     its(:stdout) { should match /0: ERROR: Cannot complete Allocation/ }
   end
 
-  describe command('turnutils_uclient -u super -w super -m 1 -n 1 -M -B -z 1 127.0.0.1') do
-    its(:stdout) { should match /1: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0/ }
+  describe command('timeout 2 turnutils_uclient -u super -w super -m 1 -n 1 -M -B -z 1 127.0.0.1') do
+    its(:stdout) { should match /.*: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0/ }
   end
 
   describe file('/var/log/coturn/turnserver.log') do


### PR DESCRIPTION
On Debian-7.
Is it flaky?

```
Running coturn:default for Debian-7
vagrant plugin list
vagrant status Debian-7
vagrant snapshot list Debian-7
vagrant snapshot go Debian-7 default
vagrant ssh-config Debian-7 > /tmp/20160108-22238-1w69pqs
Puppet applying: `/vagrant/modules/coturn/spec/default/manifest.pp`
Notice: Compiled catalog for debian-7-amd64-default.vagrantup.com in environment production in 0.55 seconds
Notice: /Stage[main]/Apt::Source::Cargomedia/Apt::Source[cargomedia]/File[/etc/apt/sources.list.d/cargomedia.list]/ensure: defined content as '{md5}15b36a21941baab4d98e2f2562a40752'
Notice: /Stage[main]/Apt::Source::Cargomedia/Apt::Source[cargomedia]/Apt::Key[cargomedia]/Exec[Add deb signature key for cargomedia]/returns: executed successfully
Notice: /Stage[main]/Logrotate/File[/etc/logrotate.conf]/content: content changed '{md5}176edd439a499501372cf3d04e795810' to '{md5}63589c8141e8a990cc0b720f9a06da1e'
Notice: /Stage[main]/Apt::Update/Exec[apt_update]/returns: executed successfully
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 2 events
Notice: /Stage[main]/Coturn/Package[coturn]/ensure: ensure changed 'purged' to 'present'
Notice: /Stage[main]/Coturn/File[/etc/coturn]/ensure: created
Notice: /Stage[main]/Coturn/File[/etc/coturn/turnserver.conf]/ensure: defined content as '{md5}ed950a7945ab89a506a4530ab030027a'
Notice: /Stage[main]/Coturn/File[/var/log/coturn]/ensure: created
Notice: /Stage[main]/Coturn/File[/var/log/coturn/turnserver.log]/ensure: created
Notice: /Stage[main]/Coturn/Daemon[coturn]/Sysvinit::Script[coturn]/File[/etc/init.d/coturn]/content: content changed '{md5}2fc1c18f91c0834b8a66bed25e4eb489' to '{md5}9a30e4a8b81d460b90e0e2c79f87f269'
Notice: /Stage[main]/Coturn/Daemon[coturn]/Sysvinit::Script[coturn]/Exec[/etc/init.d/coturn start]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Coturn/Daemon[coturn]/Service[coturn]: Triggered 'refresh' from 3 events
Notice: /Stage[main]/Coturn/Logrotate::Entry[coturn]/File[/etc/logrotate.d/coturn]/ensure: defined content as '{md5}799b5a4ae09253faff798341009ba407'
Notice: Finished catalog run in 9.46 seconds
vagrant ssh-config Debian-7 > /tmp/20160108-22238-40ukm8
Failure! 12 examples, 1 failure
Failed examples:

    coturn Command "timeout 2 turnutils_uclient -u super -w super -m 1 -n 1 -M -B -z 1 127.0.0.1" stdout should match /1: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0/
    RSpec::Expectations::ExpectationNotMetError:
      expected "0: Total connect time is 0\n0: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0\n2: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0\n" to match /1: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0/
      Diff:
      @@ -1,2 +1,4 @@
      -/1: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0/
      +0: Total connect time is 0
      +0: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0
      +2: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0
```