### PR TITLE
irqbalance module

### DIFF
--- a/modules/irqbalance/Puppetfile
+++ b/modules/irqbalance/Puppetfile
@@ -1,0 +1,3 @@
+mod 'cargomedia/apt',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/apt'

--- a/modules/irqbalance/manifests/init.pp
+++ b/modules/irqbalance/manifests/init.pp
@@ -1,0 +1,23 @@
+class irqbalance {
+
+  require 'apt'
+
+  file { '/etc/default/irqbalance':
+    ensure  => file,
+    content => template("${module_name}/default"),
+    owner   => '0',
+    group   => '0',
+    mode    => '0755',
+    notify  => Service['irqbalance'],
+  }
+  ->
+
+  package { 'irqbalance':
+    provider => 'apt',
+  }
+  ->
+
+  service { 'irqbalance':
+    enable  => true,
+  }
+}

--- a/modules/irqbalance/metadata.json
+++ b/modules/irqbalance/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "irqbalance",
+  "version": "0.0.1",
+  "author": "Cargo Media",
+  "license": "MIT",
+  "summary": "irqbalance",
+  "source": "https://github.com/cargomedia/puppet-packages",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "15.04"
+      ]
+    }
+  ],
+  "dependencies": [
+  ]
+}

--- a/modules/irqbalance/spec/init/manifest.pp
+++ b/modules/irqbalance/spec/init/manifest.pp
@@ -1,0 +1,4 @@
+node default {
+
+  require 'irqbalance'
+}

--- a/modules/irqbalance/spec/init/spec.rb
+++ b/modules/irqbalance/spec/init/spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'irqbalance' do
+
+  describe package('irqbalance') do
+    it { should be_installed }
+  end
+end

--- a/modules/irqbalance/templates/default
+++ b/modules/irqbalance/templates/default
@@ -1,0 +1,8 @@
+#Configuration for the irqbalance daemon
+
+#Should irqbalance be enabled?
+ENABLED="1"
+#Balance the IRQs only once?
+ONESHOT="0"
+
+OPTIONS="--hintpolicy=ignore"


### PR DESCRIPTION
To configure `/etc/default/irqbalance` with: `OPTIONS="--hintpolicy=ignore"`

Right now, the `irqbalance` daemon is spamming syslog all 10 seconds:

```
2016-01-20T13:02:01.005746+00:00 bulldog3 /usr/sbin/irqbalance: irq 88 affinity_hint subset empty
2016-01-20T13:02:01.005956+00:00 bulldog3 /usr/sbin/irqbalance: irq 89 affinity_hint subset empty
2016-01-20T13:02:01.006162+00:00 bulldog3 /usr/sbin/irqbalance: irq 90 affinity_hint subset empty
2016-01-20T13:02:01.006368+00:00 bulldog3 /usr/sbin/irqbalance: irq 91 affinity_hint subset empty
2016-01-20T13:02:01.006572+00:00 bulldog3 /usr/sbin/irqbalance: irq 92 affinity_hint subset empty
2016-01-20T13:02:01.006812+00:00 bulldog3 /usr/sbin/irqbalance: irq 93 affinity_hint subset empty
2016-01-20T13:02:01.007019+00:00 bulldog3 /usr/sbin/irqbalance: irq 94 affinity_hint subset empty
2016-01-20T13:02:01.007223+00:00 bulldog3 /usr/sbin/irqbalance: irq 95 affinity_hint subset empty
2016-01-20T13:02:01.007428+00:00 bulldog3 /usr/sbin/irqbalance: irq 96 affinity_hint subset empty
2016-01-20T13:02:01.007639+00:00 bulldog3 /usr/sbin/irqbalance: irq 97 affinity_hint subset empty
2016-01-20T13:02:11.003107+00:00 bulldog3 /usr/sbin/irqbalance: irq 66 affinity_hint subset empty
2016-01-20T13:02:11.003708+00:00 bulldog3 /usr/sbin/irqbalance: irq 67 affinity_hint subset empty
2016-01-20T13:02:11.003991+00:00 bulldog3 /usr/sbin/irqbalance: irq 68 affinity_hint subset empty
2016-01-20T13:02:11.004212+00:00 bulldog3 /usr/sbin/irqbalance: irq 69 affinity_hint subset empty
2016-01-20T13:02:11.004448+00:00 bulldog3 /usr/sbin/irqbalance: irq 70 affinity_hint subset empty
2016-01-20T13:02:11.004657+00:00 bulldog3 /usr/sbin/irqbalance: irq 71 affinity_hint subset empty
2016-01-20T13:02:11.004868+00:00 bulldog3 /usr/sbin/irqbalance: irq 74 affinity_hint subset empty
2016-01-20T13:02:11.005077+00:00 bulldog3 /usr/sbin/irqbalance: irq 75 affinity_hint subset empty
2016-01-20T13:02:11.005286+00:00 bulldog3 /usr/sbin/irqbalance: irq 76 affinity_hint subset empty
2016-01-20T13:02:11.005498+00:00 bulldog3 /usr/sbin/irqbalance: irq 77 affinity_hint subset empty
2016-01-20T13:02:11.005712+00:00 bulldog3 /usr/sbin/irqbalance: irq 88 affinity_hint subset empty
2016-01-20T13:02:11.005919+00:00 bulldog3 /usr/sbin/irqbalance: irq 89 affinity_hint subset empty
2016-01-20T13:02:11.006125+00:00 bulldog3 /usr/sbin/irqbalance: irq 90 affinity_hint subset empty
2016-01-20T13:02:11.006336+00:00 bulldog3 /usr/sbin/irqbalance: irq 91 affinity_hint subset empty
```

See https://bugs.launchpad.net/ubuntu/+source/irqbalance/+bug/1321425 for details