### PR TITLE
Make temporary janus directories world-writable

### DIFF
--- a/modules/janus/manifests/init.pp
+++ b/modules/janus/manifests/init.pp
@@ -52,11 +52,16 @@ class janus (
       owner  => '0',
       group  => '0',
       mode   => '0644';
-    ['/var/lib/janus', '/var/lib/janus/recordings', '/var/lib/janus/jobs']:
+    ['/var/lib/janus']:
       ensure => directory,
       owner  => 'janus',
       group  => 'janus',
       mode   => '0644';
+    ['/var/lib/janus/recordings', '/var/lib/janus/jobs']:
+      ensure => directory,
+      owner  => 'janus',
+      group  => 'janus',
+      mode   => '0666';
     '/var/log/janus':
       ensure => directory,
       owner  => 'janus',


### PR DESCRIPTION
@tomaszdurka please review

To delete a file you need write permissions on the containing directory (!).
I understand there are no sub-directories, but only flat files in these two folders, right?

cc @kris-lab