### PR TITLE
Wrapping script for hpssacli

### DIFF
--- a/modules/raid/templates/hpssacli/hpssacli-status
+++ b/modules/raid/templates/hpssacli/hpssacli-status
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-hpssacli -exitonerror controller all show config
+hpssacli -exitonerror controller all show config | grep --invert-match -Ei 'failed|error'


### PR DESCRIPTION
`hpssacli -exitonerror controller all show config` exits with 0 when the RAID is not good

Needs some more logic built into it

(Follow up of #1131)