### PR TITLE
Janus: add bipbip/logparser for missing key-frames detection

### DIFF
--- a/modules/janus/manifests/init.pp
+++ b/modules/janus/manifests/init.pp
@@ -104,16 +104,4 @@ class janus (
     user    => 'janus',
     require => [File[$config_file, $plugin_config_dir, $log_file]],
   }
-
-  @bipbip::entry { 'logparser-janus-keyframe-overdue':
-    plugin  => 'log-parser',
-    options => {
-      'metric_group' => 'janus-rtpbroadcast',
-      'path' => $log_file,
-      'matchers' => [
-        { 'name' => 'streams_keyframe_overdue',
-          'regexp' => 'Key frame overdue on source' },
-      ]
-    },
-  }
 }

--- a/modules/janus/manifests/init.pp
+++ b/modules/janus/manifests/init.pp
@@ -71,7 +71,7 @@ class janus (
   ->
 
   file {
-    '/var/log/janus/janus.log':
+    $log_file:
       ensure => file,
       owner  => 'janus',
       group  => 'janus',

--- a/modules/janus/manifests/init.pp
+++ b/modules/janus/manifests/init.pp
@@ -104,4 +104,16 @@ class janus (
     user    => 'janus',
     require => [File[$config_file, $plugin_config_dir, $log_file]],
   }
+
+  @bipbip::entry { 'logparser-janus-keyframe-overdue':
+    plugin  => 'log-parser',
+    options => {
+      'metric_group' => 'janus-rtpbroadcast',
+      'path' => $log_file,
+      'matchers' => [
+        { 'name' => 'streams_keyframe_overdue',
+          'regexp' => 'Key frame overdue on source' },
+      ]
+    },
+  }
 }

--- a/modules/janus/manifests/plugin/rtpbroadcast.pp
+++ b/modules/janus/manifests/plugin/rtpbroadcast.pp
@@ -72,7 +72,7 @@ class janus::plugin::rtpbroadcast(
     plugin  => 'log-parser',
     options => {
       'metric_group' => 'janus-rtpbroadcast',
-      'path' => janus::log_file,
+      'path' => $janus::log_file,
       'matchers' => [
         { 'name' => 'streams_keyframe_overdue',
           'regexp' => 'Key frame overdue on source' },

--- a/modules/janus/manifests/plugin/rtpbroadcast.pp
+++ b/modules/janus/manifests/plugin/rtpbroadcast.pp
@@ -67,4 +67,16 @@ class janus::plugin::rtpbroadcast(
       'url' => $rest_url,
     }
   }
+
+  @bipbip::entry { 'logparser-janus-keyframe-overdue':
+    plugin  => 'log-parser',
+    options => {
+      'metric_group' => 'janus-rtpbroadcast',
+      'path' => janus::log_file,
+      'matchers' => [
+        { 'name' => 'streams_keyframe_overdue',
+          'regexp' => 'Key frame overdue on source' },
+      ]
+    },
+  }
 }


### PR DESCRIPTION
```
[ERR] [libjanus_rtpbroadcast.c:cm_rtpbcast_relay_thread:2270] [Ababagalamaga] Key frame overdue on source 3
[ERR] [libjanus_rtpbroadcast.c:cm_rtpbcast_relay_thread:2270] [Ababagalamaga] Key frame overdue on source 1
[ERR] [libjanus_rtpbroadcast.c:cm_rtpbcast_relay_thread:2270] [Ababagalamaga] Key frame overdue on source 2
[ERR] [libjanus_rtpbroadcast.c:cm_rtpbcast_relay_thread:2262] [Ababagalamaga] Key frame arriveed 200 frames late on source 3
[ERR] [libjanus_rtpbroadcast.c:cm_rtpbcast_relay_thread:2262] [Ababagalamaga] Key frame arriveed 200 frames late on source 1
[ERR] [libjanus_rtpbroadcast.c:cm_rtpbcast_relay_thread:2262] [Ababagalamaga] Key frame arriveed 200 frames late on source 2
```

https://github.com/cargomedia/janus-gateway-rtpbroadcast/blob/master/libjanus_rtpbroadcast.c#L2261