### PR TITLE
Configure bundler install path

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: .bundle/vendor
+BUNDLE_DISABLE_SHARED_GEMS: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vagrant
 /.proxy-cache
+/.bundle/vendor

--- a/build-ci.sh
+++ b/build-ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 cd $(dirname $0)
 
-bundle install --path=.bundle
+bundle install
 
 trap 'bundle exec rake spec:cleanup' EXIT
 


### PR DESCRIPTION
To avoid conflicts with binaries in the global bundler path
Related to: https://github.com/cargomedia/osx-setup/issues/105

@ppp0 @kris-lab please review
I suggest we stick to this convention in all repos where it makes sense

cc @tomaszdurka