### PR TITLE
Drop unused /etc/aliases to manage email forwards in postfix

### DIFF
--- a/modules/postfix/manifests/init.pp
+++ b/modules/postfix/manifests/init.pp
@@ -59,23 +59,6 @@ class postfix ($aliases = { }, $transports = []) {
     notify      => Service['postfix'],
   }
 
-  file { '/etc/aliases':
-    ensure => file,
-    content => template("${module_name}/aliases"),
-    group  => '0',
-    owner  => '0',
-    mode   => '0644',
-    notify  => Exec['newaliases'],
-    before  => Package['postfix'],
-  }
-
-  exec { 'newaliases':
-    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-    refreshonly => true,
-    require     => Package['postfix'],
-    notify      => Service['postfix'],
-  }
-
   package { ['postfix', 'libsasl2-modules', 'bsd-mailx', 'procmail']:
     ensure   => present,
     provider => 'apt',

--- a/modules/postfix/metadata.json
+++ b/modules/postfix/metadata.json
@@ -8,9 +8,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystemrelease": [ "7", "8"]
     },
     {
       "operatingsystem": "Ubuntu",

--- a/modules/postfix/templates/aliases
+++ b/modules/postfix/templates/aliases
@@ -1,1 +1,0 @@
-postmaster: root

--- a/modules/postfix/templates/main.cf
+++ b/modules/postfix/templates/main.cf
@@ -4,8 +4,8 @@ append_dot_mydomain = no
 myhostname = <%= @domain || 'localhost' %>
 mydestination = localhost
 virtual_alias_maps = hash:/etc/postfix/virtual
-alias_database = hash:/etc/aliases
-alias_maps = hash:/etc/aliases
+alias_database =
+alias_maps =
 
 inet_interfaces = 127.0.0.1
 biff = no

--- a/modules/postfix/templates/virtual
+++ b/modules/postfix/templates/virtual
@@ -1,3 +1,5 @@
+mailer-daemon	postmaster
+postmaster	root
 <% @aliases.each do |from, to| -%>
 <%= from %> 	<%= to %>
 <% end %>


### PR DESCRIPTION
Via https://github.com/cargomedia/puppet-packages/pull/1167
E.g. with:
```
bundle exec rake spec:cron os=Debian-7 keep_box=true
```

Before:
```
vagrant@debian-7-amd64-default:~$ cat /etc/aliases
postmaster: root
monit: root
```
After:
```
vagrant@debian-7-amd64-default:~$ cat /etc/aliases
postmaster: root
```