### PR TITLE
[Jessie] - Migration of composer and php5

### DIFF
--- a/modules/composer/manifests/init.pp
+++ b/modules/composer/manifests/init.pp
@@ -4,7 +4,6 @@ class composer($version = '1.0.0-alpha10') {
 
   $phar = '/usr/local/lib/composer.phar'
   $binary = '/usr/local/bin/composer'
-  $config = '/etc/php5/conf.d/composer.ini'
 
   exec { "curl ${phar}":
     command => "curl -sL http://getcomposer.org/download/${version}/composer.phar > ${phar}",
@@ -21,14 +20,4 @@ class composer($version = '1.0.0-alpha10') {
     mode    => '0755',
   }
 
-  if $::lsbdistcodename == 'wheezy' {
-    file { $config:
-      ensure  => file,
-      content => template("${module_name}/composer.ini"),
-      owner   => '0',
-      group   => '0',
-      mode    => '0644',
-      before => Exec["curl ${phar}"],
-    }
-  }
 }

--- a/modules/composer/manifests/init.pp
+++ b/modules/composer/manifests/init.pp
@@ -10,7 +10,7 @@ class composer($version = '1.0.0-alpha10') {
     command => "curl -sL http://getcomposer.org/download/${version}/composer.phar > ${phar}",
     path    => ['/usr/local/bin', '/usr/bin', '/bin'],
     unless  => "${binary} --version | grep -w '${version}'",
-    require => [File[$binary], File[$config]],
+    require => [File[$binary]],
   }
 
   file { $binary:
@@ -21,11 +21,14 @@ class composer($version = '1.0.0-alpha10') {
     mode    => '0755',
   }
 
-  file { $config:
-    ensure  => file,
-    content => template("${module_name}/composer.ini"),
-    owner   => '0',
-    group   => '0',
-    mode    => '0644',
+  if $::lsbdistcodename == 'wheezy' {
+    file { $config:
+      ensure  => file,
+      content => template("${module_name}/composer.ini"),
+      owner   => '0',
+      group   => '0',
+      mode    => '0644',
+      before => Exec["curl ${phar}"],
+    }
   }
 }

--- a/modules/composer/metadata.json
+++ b/modules/composer/metadata.json
@@ -8,7 +8,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["7"]
+      "operatingsystemrelease": ["7", "8"]
     }
   ],
   "dependencies": [

--- a/modules/composer/spec/default/spec.rb
+++ b/modules/composer/spec/default/spec.rb
@@ -6,9 +6,4 @@ describe 'composer' do
     its(:exit_status) { should eq 0 }
   end
 
-  describe 'PHP config parameters' do
-    context php_config('suhosin.executor.include.whitelist') do
-      its(:value) { should eq 'phar' }
-    end
-  end
 end

--- a/modules/composer/templates/composer.ini
+++ b/modules/composer/templates/composer.ini
@@ -1,1 +1,0 @@
-suhosin.executor.include.whitelist = phar


### PR DESCRIPTION
Follow-up of https://github.com/cargomedia/puppet-packages/pull/1150
Needs #1164 https://github.com/cargomedia/puppet-packages/issues/1168

Make following modules run on Jessie:
- [x] composer
- [x] php5