### PR TITLE
Fix bipbip/mongo monitoring credentials

### DIFF
--- a/modules/mongodb/manifests/core/mongod.pp
+++ b/modules/mongodb/manifests/core/mongod.pp
@@ -80,13 +80,15 @@ define mongodb::core::mongod (
   }
 
   $hostName = $bind_ip? { undef => 'localhost', default => $bind_ip }
+  $monitoringUser = $monitoring_credentials['user'] ? { undef => '', default => $monitoring_credentials['user'] }
+  $monitoringPassword = $monitoring_credentials['password'] ? { undef => '', default => $monitoring_credentials['password'] }
   @bipbip::entry { $instance_name:
     plugin  => 'mongodb',
     options => {
       'hostname' => $hostName,
       'port' => $port,
-      'user' => $monitoring_credentials['user'],
-      'password' => $monitoring_credentials['password'],
+      'user' => $monitoringUser,
+      'password' => $monitoringPassword,
     }
   }
 

--- a/modules/mongodb/manifests/core/mongos.pp
+++ b/modules/mongodb/manifests/core/mongos.pp
@@ -70,13 +70,15 @@ define mongodb::core::mongos (
   }
 
   $hostName = $bind_ip? { undef => 'localhost', default => $bind_ip }
+  $monitoringUser = $monitoring_credentials['user'] ? { undef => '', default => $monitoring_credentials['user'] }
+  $monitoringPassword = $monitoring_credentials['password'] ? { undef => '', default => $monitoring_credentials['password'] }
   @bipbip::entry { $instance_name:
     plugin  => 'mongodb',
     options => {
       'hostname' => $hostName,
       'port' => $port,
-      'user' => $monitoring_credentials['user'],
-      'password' => $monitoring_credentials['password'],
+      'user' => $monitoringUser,
+      'password' => $monitoringPassword,
     }
   }
 


### PR DESCRIPTION
Fixes for
````
$ cat /etc/bipbip/services.d/mongod_standalone.yml 
--- 
  plugin: mongodb
  hostname: "0.0.0.0"
  port: "27017"
  user: !ruby/sym undef
  password: !ruby/sym undef
```