### PR TITLE
Cont: Fix bipbip/mongo monitoring credentials

### DIFF
--- a/modules/bipbip/templates/service
+++ b/modules/bipbip/templates/service
@@ -1,2 +1,2 @@
 <% require 'psych' -%>
-<%= Psych.dump({'plugin' => @plugin}.merge(@options)) %>
+<%= Psych.dump({'plugin' => @plugin}.merge(@options).reject{|k, v| v.nil? }) %>

--- a/modules/mongodb/manifests/core/mongod.pp
+++ b/modules/mongodb/manifests/core/mongod.pp
@@ -80,15 +80,13 @@ define mongodb::core::mongod (
   }
 
   $hostName = $bind_ip? { undef => 'localhost', default => $bind_ip }
-  $monitoringUser = $monitoring_credentials['user'] ? { undef => '', default => $monitoring_credentials['user'] }
-  $monitoringPassword = $monitoring_credentials['password'] ? { undef => '', default => $monitoring_credentials['password'] }
   @bipbip::entry { $instance_name:
     plugin  => 'mongodb',
     options => {
       'hostname' => $hostName,
       'port' => $port,
-      'user' => $monitoringUser,
-      'password' => $monitoringPassword,
+      'user' => $monitoring_credentials['user'],
+      'password' => $monitoring_credentials['password'],
     }
   }
 

--- a/modules/mongodb/manifests/core/mongos.pp
+++ b/modules/mongodb/manifests/core/mongos.pp
@@ -70,15 +70,13 @@ define mongodb::core::mongos (
   }
 
   $hostName = $bind_ip? { undef => 'localhost', default => $bind_ip }
-  $monitoringUser = $monitoring_credentials['user'] ? { undef => '', default => $monitoring_credentials['user'] }
-  $monitoringPassword = $monitoring_credentials['password'] ? { undef => '', default => $monitoring_credentials['password'] }
   @bipbip::entry { $instance_name:
     plugin  => 'mongodb',
     options => {
       'hostname' => $hostName,
       'port' => $port,
-      'user' => $monitoringUser,
-      'password' => $monitoringPassword,
+      'user' => $monitoring_credentials['user'],
+      'password' => $monitoring_credentials['password'],
     }
   }
 


### PR DESCRIPTION
cont of https://github.com/cargomedia/puppet-packages/pull/1174

`bipbip:entry` should not store any value if e.g. `undef`

````
   plugin: mongodb
   hostname: "0.0.0.0"
   port: "27017"
   user: ""
   password: ""
```

`user` and `password` should be empty/nil but not a string `""`. Otherwise `ruby-mongo` client use empty string as credentials!