### PR TITLE
Backup copy network interface - To be able to revert

### DIFF
--- a/modules/network/manifests/init.pp
+++ b/modules/network/manifests/init.pp
@@ -1,5 +1,13 @@
 class network {
 
+  exec { 'Backup existing network config':
+    provider => shell,
+    command  => 'cp /etc/network/interfaces /etc/network/interfaces.provisioned',
+    unless   => 'ls /etc/network/interfaces.provisioned',
+    path     => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    user     => 'root',
+  }
+
   $interfaces = hiera_hash('network::interfaces', { })
   create_resources('network::interface', $interfaces)
 

--- a/modules/network/manifests/init.pp
+++ b/modules/network/manifests/init.pp
@@ -1,12 +1,6 @@
 class network {
 
-  exec { 'Backup existing network config':
-    provider => shell,
-    command  => 'cp /etc/network/interfaces /etc/network/interfaces.bak',
-    unless   => 'ls /etc/network/interfaces.bak',
-    path     => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-    user     => 'root',
-  }
+  require 'network::interfaces_backup'
 
   $interfaces = hiera_hash('network::interfaces', { })
   create_resources('network::interface', $interfaces)

--- a/modules/network/manifests/init.pp
+++ b/modules/network/manifests/init.pp
@@ -2,8 +2,8 @@ class network {
 
   exec { 'Backup existing network config':
     provider => shell,
-    command  => 'cp /etc/network/interfaces /etc/network/interfaces.provisioned',
-    unless   => 'ls /etc/network/interfaces.provisioned',
+    command  => 'cp /etc/network/interfaces /etc/network/interfaces.bak',
+    unless   => 'ls /etc/network/interfaces.bak',
     path     => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     user     => 'root',
   }

--- a/modules/network/manifests/interface.pp
+++ b/modules/network/manifests/interface.pp
@@ -15,14 +15,14 @@ define network::interface (
   $applyconfig  = true,
 ) {
 
-  include ['augeas', 'network']
+  include 'augeas'
 
   case $method {
     'dhcp': {
       augeas { "main-${device}" :
         context => '/files/etc/network/interfaces',
         changes => template("${module_name}/interface/dhcp"),
-        require => [Class['augeas'], Exec['Backup existing network config']],
+        require => Class['augeas'],
       }
     }
     'static': {
@@ -35,14 +35,14 @@ define network::interface (
       augeas { "main-${device}" :
         context => '/files/etc/network/interfaces',
         changes => template("${module_name}/interface/static_manual"),
-        require => [Class['augeas'], Exec['Backup existing network config']],
+        require => Class['augeas'],
       }
     }
     'manual': {
       augeas { "main-${device}" :
         context => '/files/etc/network/interfaces',
         changes => template("${module_name}/interface/static_manual"),
-        require => [Class['augeas'], Exec['Backup existing network config']],
+        require => Class['augeas'],
       }
     }
     default: {

--- a/modules/network/manifests/interface.pp
+++ b/modules/network/manifests/interface.pp
@@ -15,14 +15,14 @@ define network::interface (
   $applyconfig  = true,
 ) {
 
-  include 'augeas'
+  include ['augeas', 'network']
 
   case $method {
     'dhcp': {
       augeas { "main-${device}" :
         context => '/files/etc/network/interfaces',
         changes => template("${module_name}/interface/dhcp"),
-        require => Class['augeas'],
+        require => [Class['augeas'], Exec['Backup existing network config']],
       }
     }
     'static': {
@@ -35,14 +35,14 @@ define network::interface (
       augeas { "main-${device}" :
         context => '/files/etc/network/interfaces',
         changes => template("${module_name}/interface/static_manual"),
-        require => Class['augeas'],
+        require => [Class['augeas'], Exec['Backup existing network config']],
       }
     }
     'manual': {
       augeas { "main-${device}" :
         context => '/files/etc/network/interfaces',
         changes => template("${module_name}/interface/static_manual"),
-        require => Class['augeas'],
+        require => [Class['augeas'], Exec['Backup existing network config']],
       }
     }
     default: {

--- a/modules/network/manifests/interfaces_backup.pp
+++ b/modules/network/manifests/interfaces_backup.pp
@@ -1,0 +1,10 @@
+class network::interfaces_backup {
+
+  exec { 'Backup existing network config':
+    provider => shell,
+    command  => 'cp /etc/network/interfaces /etc/network/interfaces.bak',
+    unless   => 'ls /etc/network/interfaces.bak',
+    path     => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    user     => 'root',
+  }
+}


### PR DESCRIPTION
In case of mistakes in network config we would be able to revert by manually restoring the backup copy of `/etc/network/interfaces`

