### PR TITLE
Janus: configurable "src_repo"

### DIFF
--- a/modules/janus/manifests/init.pp
+++ b/modules/janus/manifests/init.pp
@@ -18,6 +18,7 @@ class janus (
   $turn_rest_api = undef,
   $turn_rest_api_key = undef,
   $src_version = undef,
+  $src_repo = undef,
   $core_dump = true,
 ) {
 
@@ -33,6 +34,7 @@ class janus (
   if $src_version {
     class { 'janus::source':
       version => $src_version,
+      repo    => $src_repo,
       before  => Daemon['janus'],
       notify  => Service['janus'],
     }

--- a/modules/janus/manifests/plugin/audioroom.pp
+++ b/modules/janus/manifests/plugin/audioroom.pp
@@ -5,6 +5,7 @@ class janus::plugin::audioroom(
   $jobs_path = '/var/lib/janus/jobs',
   $job_pattern = 'job-#{md5}',
   $src_version = undef,
+  $src_repo = undef,
   $rest_url = 'http://127.0.0.1:8088/janus',
 ) {
 
@@ -31,11 +32,11 @@ class janus::plugin::audioroom(
       provider => 'apt'
     }
 
-    $plugin_repo = 'janus-gateway-audioroom'
-
-    git::repository { $plugin_repo:
-      remote    => "https://github.com/cargomedia/${plugin_repo}.git",
-      directory => "/opt/janus/${plugin_repo}",
+    $src_path = '/opt/janus/janus-gateway-audioroom'
+    $src_remote = $src_repo ? { undef => 'https://github.com/cargomedia/janus-gateway-audioroom.git',  default => $src_repo }
+    git::repository { 'janus-gateway-audioroom':
+      remote    => $src_remote,
+      directory => $src_path,
       revision  => $src_version,
     }
     ~>

--- a/modules/janus/manifests/plugin/rtpbroadcast.pp
+++ b/modules/janus/manifests/plugin/rtpbroadcast.pp
@@ -15,6 +15,7 @@ class janus::plugin::rtpbroadcast(
   $jobs_path = '/var/lib/janus/jobs',
   $job_pattern = 'job-#{md5}',
   $src_version = undef,
+  $src_repo = undef,
   $rest_url = 'http://127.0.0.1:8088/janus',
 ) {
 
@@ -37,11 +38,11 @@ class janus::plugin::rtpbroadcast(
     require 'build::dev::libglib2'
     require 'build::dev::libjansson'
 
-    $plugin_repo = 'janus-gateway-rtpbroadcast'
-
-    git::repository { $plugin_repo:
-      remote    => "https://github.com/cargomedia/${plugin_repo}.git",
-      directory => "/opt/janus/${plugin_repo}",
+    $src_path = '/opt/janus/janus-gateway-rtpbroadcast'
+    $src_remote = $src_repo ? { undef => 'https://github.com/cargomedia/janus-gateway-rtpbroadcast.git',  default => $src_repo }
+    git::repository { 'janus-gateway-rtpbroadcast':
+      remote    => $src_remote,
+      directory => $src_path,
       revision  => $src_version,
     }
     ~>
@@ -72,9 +73,9 @@ class janus::plugin::rtpbroadcast(
     plugin  => 'log-parser',
     options => {
       'metric_group' => 'janus-rtpbroadcast',
-      'path' => $janus::log_file,
-      'matchers' => [
-        { 'name' => 'streams_keyframe_overdue',
+      'path'         => $janus::log_file,
+      'matchers'     => [
+        { 'name'   => 'streams_keyframe_overdue',
           'regexp' => 'Key frame overdue on source' },
       ]
     },

--- a/modules/janus/manifests/source.pp
+++ b/modules/janus/manifests/source.pp
@@ -1,5 +1,6 @@
 class janus::source (
-  $version
+  $version,
+  $repo = undef
 ) {
 
   require 'apt'
@@ -10,6 +11,8 @@ class janus::source (
   require 'build::libtool'
   require 'build::dev::libglib2'
   require 'build::dev::libjansson'
+
+  $src_remote = $repo ? { undef => 'https://github.com/meetecho/janus-gateway.git',  default => $repo }
 
   package { [
     'libsrtp',
@@ -33,7 +36,7 @@ class janus::source (
   ->
 
   git::repository { 'Janus Gateway':
-    remote    => 'https://github.com/meetecho/janus-gateway.git',
+    remote    => $src_remote,
     directory => '/opt/janus/janus-gateway',
     revision  => $version,
   }

--- a/modules/janus/templates/plugin_install.sh
+++ b/modules/janus/templates/plugin_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-cd /opt/janus/<%= @plugin_repo %>
+cd "<%= @src_path %>"
 ./autogen.sh
 ./configure --prefix=/usr
 make


### PR DESCRIPTION
Currently janus and plugin resources allow to be installed from a specific `src_version` (git sha). For testing different versions it would be useful if we could also provide the `src_repo`.
E.g. for https://github.com/cargomedia/janus-testing

@ppp0 @kris-lab wdyt?