### PR TITLE
Require "apt" for "percona_toolkit" because installer uses DPKG

### DIFF
--- a/modules/elasticsearch/Puppetfile
+++ b/modules/elasticsearch/Puppetfile
@@ -1,3 +1,7 @@
+mod 'cargomedia/apt',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/apt'
+
 mod 'cargomedia/java',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/java'

--- a/modules/elasticsearch/manifests/init.pp
+++ b/modules/elasticsearch/manifests/init.pp
@@ -4,6 +4,7 @@ class elasticsearch (
   $cluster_name = undef
 ) {
 
+  require 'apt'
   require 'java'
 
   $version = '1.3.1'
@@ -37,7 +38,8 @@ class elasticsearch (
 
   helper::script { 'install elasticsearch':
     content => template("${module_name}/install.sh"),
-    unless  => "/usr/share/elasticsearch/bin/elasticsearch -v | grep -q '\s${version},'"
+    unless  => "/usr/share/elasticsearch/bin/elasticsearch -v | grep -q '\s${version},'",
+    require => Class['apt::update'],
   }
   ->
 

--- a/modules/mms/Puppetfile
+++ b/modules/mms/Puppetfile
@@ -1,3 +1,7 @@
+mod 'cargomedia/apt',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/apt'
+
 mod 'cargomedia/monit',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/monit'

--- a/modules/mms/manifests/agent/backup.pp
+++ b/modules/mms/manifests/agent/backup.pp
@@ -6,6 +6,7 @@ class mms::agent::backup (
 
 # Docu: https://docs.mms.mongodb.com/tutorial/install-backup-agent-with-deb-package/
 
+  require 'apt'
   require 'mms'
 
   $agent_name = 'mms-backup'
@@ -14,6 +15,7 @@ class mms::agent::backup (
   helper::script { 'install-mms-backup':
     content => template("${module_name}/install.sh"),
     unless  => "(test -x /usr/bin/mongodb-${agent_name}-agent) && (/usr/bin/mongodb-${agent_name}-agent -version | grep -q ${version})",
+    require => Class['apt::update'],
   }
 
   file { '/etc/mongodb-mms/backup-agent.config':

--- a/modules/mms/manifests/agent/monitoring.pp
+++ b/modules/mms/manifests/agent/monitoring.pp
@@ -9,6 +9,7 @@ class mms::agent::monitoring (
 
   # Docu: https://docs.mms.mongodb.com/tutorial/install-monitoring-agent-with-deb-package/
 
+  require 'apt'
   require 'mms'
 
   $agent_name = 'mms-monitoring'
@@ -17,6 +18,7 @@ class mms::agent::monitoring (
   helper::script { 'install-mms-monitoring':
     content => template("${module_name}/install.sh"),
     unless  => "(test -x /usr/bin/mongodb-${agent_name}-agent) && (/usr/bin/mongodb-${agent_name}-agent -version | grep -q ${version})",
+    require => Class['apt::update'],
   }
 
   file { '/etc/mongodb-mms/monitoring-agent.config':

--- a/modules/percona_toolkit/Puppetfile
+++ b/modules/percona_toolkit/Puppetfile
@@ -1,3 +1,7 @@
+mod 'cargomedia/apt',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/apt'
+
 mod 'cargomedia/helper',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/helper'

--- a/modules/percona_toolkit/manifests/init.pp
+++ b/modules/percona_toolkit/manifests/init.pp
@@ -1,10 +1,13 @@
 class percona_toolkit {
 
+  require 'apt'
+
   $version = '2.2.5-2'
   $version_nobuild = regsubst($version, '-[^-]+$', '')
 
   helper::script { 'install percona-toolkit':
     content => template("${module_name}/install.sh"),
-    unless  => "pt-online-schema-change --version | grep -w ${version_nobuild}"
+    unless  => "pt-online-schema-change --version | grep -w ${version_nobuild}",
+    require => Class['apt::update'],
   }
 }

--- a/modules/puppet/manifests/common.pp
+++ b/modules/puppet/manifests/common.pp
@@ -2,9 +2,12 @@ class puppet::common(
   $basemodulepath = '/etc/puppet/modules'
 ) {
 
+  require 'apt'
+
   helper::script { 'install puppet apt sources':
     content => template("${module_name}/install-apt-sources.sh"),
     unless  => "dpkg-query -f '\${Status}\n' -W puppetlabs-release* | grep -q 'ok installed'",
+    require => Class['apt::update'],
   }
 
   file { '/var/lib/puppet':

--- a/modules/vagrant/Puppetfile
+++ b/modules/vagrant/Puppetfile
@@ -1,3 +1,7 @@
 mod 'cargomedia/helper',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/helper'
+
+mod 'cargomedia/apt',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/apt'

--- a/modules/vagrant/manifests/init.pp
+++ b/modules/vagrant/manifests/init.pp
@@ -3,9 +3,12 @@ class vagrant {
   $version = '1.7.3'
   $url = 'https://releases.hashicorp.com/vagrant/1.7.3/vagrant_1.7.3_x86_64.deb'
 
+  require 'apt'
+
   helper::script { 'install vagrant':
     content     => template("${module_name}/install.sh"),
     unless      => "vagrant --version | grep '^Vagrant ${version}$'",
     environment => ['HOME=/tmp'],   # Vagrant needs $HOME (https://github.com/mitchellh/vagrant/issues/2215)
+    require => Class['apt::update'],
   }
 }


### PR DESCRIPTION
dpkg used in the installer, so we need to make sure apt indices are up-to-date.

@ppp0 please review