### PR TITLE
Move UFW log out of syslog?

### DIFF
--- a/modules/rsyslog/manifests/init.pp
+++ b/modules/rsyslog/manifests/init.pp
@@ -19,13 +19,10 @@ class rsyslog(
       group     => '0',
       mode      => '0644',
       notify    => Service['rsyslog'];
-    '/etc/rsyslog.d/50-default.conf':
-      ensure  => file,
-      owner   => '0',
-      group   => '0',
-      mode    => '0644',
-      content => template("${module_name}/rules.conf.erb"),
-      notify    => Service['rsyslog'];
+  }
+
+  rsyslog::config { '50-default':
+    content => template("${module_name}/rules.conf.erb"),
   }
 
   file { '/var/log/syslog':

--- a/modules/rsyslog/templates/rules.conf.erb
+++ b/modules/rsyslog/templates/rules.conf.erb
@@ -39,7 +39,7 @@ news.notice			-/var/log/news/news.notice
 #
 # Emergencies are sent to everybody logged in.
 #
-*.emerg				*
+*.emerg				:omusrmsg:*
 
 #
 # I like to have messages displayed on the console, but only on a virtual

--- a/modules/ufw/Puppetfile
+++ b/modules/ufw/Puppetfile
@@ -5,3 +5,11 @@ mod 'cargomedia/apt',
 mod 'puppetlabs/stdlib',
   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git',
   :ref => '4.1.0'
+
+mod 'cargomedia/rsyslog',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/rsyslog'
+
+mod 'cargomedia/logrotate',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/logrotate'

--- a/modules/ufw/manifests/init.pp
+++ b/modules/ufw/manifests/init.pp
@@ -17,6 +17,30 @@ class ufw {
     recurse => true,
   }
 
+  file { '/var/log/ufw':
+    ensure  => directory,
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+  }
+
+  file { '/var/log/ufw/ufw.log':
+    ensure  => file,
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+  }
+  ->
+
+  rsyslog::config { '20-ufw':
+    content => template("${module_name}/rsyslog"),
+  }
+  ->
+
+  logrotate::entry { $module_name:
+    content => template("${module_name}/logrotate")
+  }
+
   Ufw::Application <| |> -> Exec['Activate ufw']
   Ufw::Rule <| |> -> Exec['Activate ufw']
 }

--- a/modules/ufw/manifests/init.pp
+++ b/modules/ufw/manifests/init.pp
@@ -8,6 +8,11 @@ class ufw {
     provider => 'apt',
   }
 
+  $rsyslog_stop_command = $::lsbdistcodename ? {
+    'wheezy' => '~',
+    default => 'stop',
+  }
+
   file { '/etc/ufw/applications.d':
     ensure  => directory,
     owner   => '0',
@@ -33,7 +38,7 @@ class ufw {
   ->
 
   rsyslog::config { '20-ufw':
-    content => template("${module_name}/rsyslog"),
+    content => template("${module_name}/rsyslog.erb"),
   }
   ->
 

--- a/modules/ufw/spec/default/manifest.pp
+++ b/modules/ufw/spec/default/manifest.pp
@@ -1,0 +1,21 @@
+node default {
+
+  ufw::rule { 'allow 22 - otherwise tests wont run :)':
+    app_or_port => '22',
+  }
+
+  exec { 'log test':
+    command     => 'logger [UFW Block] foo to bar',
+    provider    => shell,
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    require     => [Class['ufw'],Service['rsyslog']],
+  }
+  ->
+
+  exec { 'rotate ufw log':
+    command     => 'logrotate -f /etc/logrotate.conf',
+    provider    => shell,
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    require     => [Class['ufw'],Service['rsyslog']],
+  }
+}

--- a/modules/ufw/spec/default/spec.rb
+++ b/modules/ufw/spec/default/spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'ufw::default' do
+
+  describe package('ufw') do
+    it { should be_installed }
+  end
+
+  describe file('/var/log/ufw/ufw.log.1') do
+    it { should be_file }
+    its(:content) { should match /foo to bar/}
+  end
+
+  describe file ('/var/log/ufw/ufw.log') do
+    it { should be_file }
+  end
+
+  describe file ('/var/log/syslog') do
+    its(:content) { should_not match /foo to bar/}
+  end
+
+end

--- a/modules/ufw/spec/default/spec.rb
+++ b/modules/ufw/spec/default/spec.rb
@@ -11,12 +11,12 @@ describe 'ufw::default' do
     its(:content) { should match /foo to bar/}
   end
 
-  describe file ('/var/log/ufw/ufw.log') do
-    it { should be_file }
+  describe file ('/var/log/syslog.1') do
+    its(:content) { should_not match /foo to bar/}
   end
 
-  describe file ('/var/log/syslog') do
-    its(:content) { should_not match /foo to bar/}
+  describe file ('/var/log/ufw/ufw.log') do
+    it { should be_file }
   end
 
 end

--- a/modules/ufw/templates/logrotate
+++ b/modules/ufw/templates/logrotate
@@ -1,0 +1,12 @@
+/var/log/ufw/ufw.log {
+	rotate 7
+	daily
+	delaycompress
+	compress
+	notifempty
+	missingok
+	create 644
+	postrotate
+		/etc/init.d/rsyslog rotate > /dev/null 2>&1 || true
+	endscript
+}

--- a/modules/ufw/templates/rsyslog
+++ b/modules/ufw/templates/rsyslog
@@ -1,0 +1,7 @@
+# Log kernel generated UFW log messages to file
+:msg,contains,"[UFW " /var/log/ufw/ufw.log
+
+# Uncomment the following to stop logging anything that matches the last rule.
+# Doing this will stop logging kernel generated UFW log messages to the file
+# normally containing kern.* messages (eg, /var/log/kern.log)
+& stop

--- a/modules/ufw/templates/rsyslog.erb
+++ b/modules/ufw/templates/rsyslog.erb
@@ -4,4 +4,4 @@
 # Uncomment the following to stop logging anything that matches the last rule.
 # Doing this will stop logging kernel generated UFW log messages to the file
 # normally containing kern.* messages (eg, /var/log/kern.log)
-& stop
+& <%= @rsyslog_stop_command %>


### PR DESCRIPTION
Currently syslog is quite spammed:
```

2016-03-08T05:46:01.215166-06:00 janus2 kernel: [5520199.120423] [UFW BLOCK] IN=eth1 OUT= MAC=00:25:90:2f:48:dd:00:08:e3:ff:fd:90:08:00 SRC=58.147.182.133 DST=5.153.28.157 LEN=60 TOS=0x00 PREC=0x00 TTL=49 ID=20560 DF PROTO=TCP SPT=3909 DPT=23 WINDOW=5840 RES=0x00 SYN URGP=0
```

@ppp0 @kris-lab  wdyt?