### PR TITLE
Janus: Load modules before daemon starts

### DIFF
--- a/modules/janus/manifests/transport/websockets.pp
+++ b/modules/janus/manifests/transport/websockets.pp
@@ -31,6 +31,7 @@ define janus::transport::websockets(
     ensure    => link,
     target    => '/usr/lib/janus/transports/libjanus_websockets.so',
   }
+  ->
 
   file { "${instance_base_dir}/etc/janus/janus.transport.websockets.cfg":
     ensure    => 'present',


### PR DESCRIPTION
Seems that modules are loaded after initial start of janus.

Currently we have this:
```puppet
  file { "${instance_base_dir}/usr/lib/janus/transports.enabled/libjanus_websockets.so":
    ensure    => link,
    target    => '/usr/lib/janus/transports/libjanus_websockets.so',
  }

  file { "${instance_base_dir}/etc/janus/janus.transport.websockets.cfg":
    ensure    => 'present',
    content   => template("${module_name}/transport/websockets.cfg"),
    owner     => '0',
    group     => '0',
    mode      => '0644',
    before    => Daemon[$instance_name],
    notify    => Service[$instance_name],
  }
```

I guess we should ensure module is loaded before Daemon.

@kris-lab agree?