### PR TITLE
Disable standard page for apache2/puppetmaster

### DIFF
--- a/modules/apache2/manifests/init.pp
+++ b/modules/apache2/manifests/init.pp
@@ -32,4 +32,13 @@ class apache2 {
     ensure   => present,
     provider => 'apt',
   }
+  ~>
+
+  exec { 'Disable 000-default page and ports':
+    command     => 'a2dissite 000-default',
+    provider    => shell,
+    path        => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    refreshonly => true,
+    notify => Service['apache2'],
+  }
 }

--- a/modules/apache2/spec/init/spec.rb
+++ b/modules/apache2/spec/init/spec.rb
@@ -5,4 +5,8 @@ describe 'apache2' do
   describe package('apache2') do
     it { should be_installed }
   end
+
+  describe file('/etc/apache2/sites-enabled/000-default') do
+    it { should_not exist}
+  end
 end

--- a/modules/apache2/templates/apache2.conf
+++ b/modules/apache2/templates/apache2.conf
@@ -170,9 +170,6 @@ Include mods-enabled/*.conf
 # Include all the user configurations:
 Include httpd.conf
 
-# Include ports listing
-Include ports.conf
-
 #
 # The following directives define some format nicknames for use with
 # a CustomLog directive (see below).

--- a/modules/apache2/templates/monit
+++ b/modules/apache2/templates/monit
@@ -1,4 +1,3 @@
 check process apache2 with pidfile /var/run/apache2.pid
 	start program = "/etc/init.d/apache2 start"
 	stop program  = "/etc/init.d/apache2 stop"
-	if failed port 80 protocol http with timeout 10 seconds for 2 cycles then restart


### PR DESCRIPTION
Follow-up of https://github.com/cargomedia/puppet-packages/pull/1221

On the same box, there is apache running as front-end to puppetmaster. Implement redirector http->https in apache?

[UPDATE]

apache2/puppetmaster only needs 8141, the other default ports are live but returning the default "It works" page.. Renaming this issue