### PR TITLE
nodejs:npm spec fails

### DIFF
--- a/modules/nodejs/spec/npm/manifest.pp
+++ b/modules/nodejs/spec/npm/manifest.pp
@@ -2,7 +2,7 @@ node default {
 
   require 'nodejs'
 
-  package { 'redis':
+  package { 'socket-redis':
     provider => 'npm',
     require  => Class['nodejs'],
   }

--- a/modules/nodejs/spec/npm/spec.rb
+++ b/modules/nodejs/spec/npm/spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'package provider npm' do
 
-  describe command('npm list redis -g') do
-    its(:stdout) { should match 'redis' }
+  describe command('npm list socket-redis -g') do
+    its(:stdout) { should match 'socket-redis' }
   end
 end


### PR DESCRIPTION
The "nodejs:npm" spec fails.

The failure output contains some strange encoded string, which leads to a followup error, which let's the rspec json formatter raise an error.

Running rspec directly:
```sh
$ box=Debian-7 keep_box=true bundle exec rspec --format json modules/nodejs/spec/npm/spec.rb
vagrant ssh-config Debian-7 > /var/folders/_8/70bmqjtd7h3cm6wzlm_bbchh0000gn/T/20160403-15137-8a8ujl
Puppet applying: `/vagrant/modules/nodejs/spec/npm/manifest.pp`
Notice: Compiled catalog for debian-7-amd64-default.vagrantup.com in environment production in 0.43 seconds
Notice: Finished catalog run in 1.08 seconds
vagrant ssh-config Debian-7 > /var/folders/_8/70bmqjtd7h3cm6wzlm_bbchh0000gn/T/20160403-15137-3jvi75
/Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/formatters/json_formatter.rb:50:in `encode': "\xE2" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/formatters/json_formatter.rb:50:in `to_json'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/formatters/json_formatter.rb:50:in `close'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:189:in `block in notify'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:188:in `each'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:188:in `notify'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:214:in `close'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:177:in `close_after'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:156:in `finish'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:79:in `report'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/bin/rspec:22:in `load'
	from /Users/reto/Projects/puppet-packages/.bundle/vendor/ruby/2.1.0/bin/rspec:22:in `<main>'
```

Adjusting `rspec/core/formatters/json_formatter.rb` manually I can dump the JSON

Not using JSON output results in:
```sh
$ box=Debian-7 keep_box=true bundle exec rspec modules/nodejs/spec/npm/spec.rb
vagrant ssh-config Debian-7 > /var/folders/_8/70bmqjtd7h3cm6wzlm_bbchh0000gn/T/20160403-15199-1nabcpz
Puppet applying: `/vagrant/modules/nodejs/spec/npm/manifest.pp`
Notice: Compiled catalog for debian-7-amd64-default.vagrantup.com in environment production in 0.43 seconds
Notice: Finished catalog run in 1.09 seconds
vagrant ssh-config Debian-7 > /var/folders/_8/70bmqjtd7h3cm6wzlm_bbchh0000gn/T/20160403-15199-1n7nj5s
F

Failures:

  1) package provider npm Command "npm list redis -g" stdout should match "redis"
     Failure/Error: its(:stdout) { should match 'redis' }
       expected "/usr/lib\n\xE2\x94\x94\xE2\x94\x80\xE2\x94\x80 (empty)\n\n" to match "redis"
       Diff:
       @@ -1,2 +1,3 @@
       -redis
       +/usr/lib
       +????????? (empty)
       sudo -p 'Password: ' /bin/sh -c npm\ list\ redis\ -g
       /usr/lib
????????? (empty)


     # ./modules/nodejs/spec/npm/spec.rb:6:in `block (3 levels) in <top (required)>'

Finished in 13.46 seconds (files took 0.27783 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./modules/nodejs/spec/npm/spec.rb:6 # package provider npm Command "npm list redis -g" stdout should match "redis"
```

@ppp0 can you look into this?