### PR TITLE
Purge unmanaged xsession definitions

### DIFF
--- a/modules/lightdm/Puppetfile
+++ b/modules/lightdm/Puppetfile
@@ -2,10 +2,6 @@ mod 'cargomedia/apt',
    :git => 'git@github.com:cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
-mod 'cargomedia/daemon',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
-   :path => 'modules/daemon'
-
 mod 'cargomedia/xorg',
    :git => 'git@github.com:cargomedia/puppet-packages.git',
    :path => 'modules/xorg'

--- a/modules/lightdm/manifests/init.pp
+++ b/modules/lightdm/manifests/init.pp
@@ -28,6 +28,8 @@ class lightdm {
     owner   => '0',
     group   => '0',
     mode    => '0644',
+    purge   => true,
+    recurse => true,
     notify  => Service['lightdm'],
   }
 

--- a/modules/lightdm/manifests/xsession.pp
+++ b/modules/lightdm/manifests/xsession.pp
@@ -1,5 +1,6 @@
 define lightdm::xsession(
   $exec,
+  $entries = { },
 ) {
 
   include 'lightdm'

--- a/modules/lightdm/templates/xsession.desktop.erb
+++ b/modules/lightdm/templates/xsession.desktop.erb
@@ -1,3 +1,6 @@
 [Desktop Entry]
 Name=<%= @name %>
 Exec=<%= @exec %>
+<% @entries.each do |key, value| -%>
+<%= key %>=<%= value %>
+<% end -%>

--- a/modules/unity/Puppetfile
+++ b/modules/unity/Puppetfile
@@ -1,0 +1,7 @@
+mod 'cargomedia/apt',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/apt'
+
+mod 'cargomedia/lightdm',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/lightdm'

--- a/modules/unity/manifests/init.pp
+++ b/modules/unity/manifests/init.pp
@@ -1,0 +1,22 @@
+class unity {
+
+  include 'lightdm'
+
+  package { ['unity', 'ubuntu-session']:
+    ensure   => present,
+    provider => 'apt',
+  }
+
+  ensure_packages(['gnome-terminal'], {
+    provider => 'apt',
+  })
+
+  lightdm::xsession { 'ubuntu':
+    exec    => 'gnome-session --session=ubuntu',
+    entries  => {
+      'DesktopNames' => 'Unity',
+    },
+    require => Package['unity'],
+  }
+
+}

--- a/modules/unity/metadata.json
+++ b/modules/unity/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "cargomedia-unity",
+  "version": "0.0.1",
+  "author": "Cargo Media",
+  "license": "MIT",
+  "summary": "unity",
+  "source": "https://github.com/cargomedia/puppet-packages",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "15.04"
+      ]
+    }
+  ],
+  "dependencies": [
+  ]
+}

--- a/modules/unity/spec/default/manifest.pp
+++ b/modules/unity/spec/default/manifest.pp
@@ -1,0 +1,6 @@
+node default {
+
+  class { 'unity':
+  }
+
+}

--- a/modules/unity/spec/default/spec.rb
+++ b/modules/unity/spec/default/spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'unity' do
+
+  describe package('unity') do
+    it { should be_installed }
+  end
+
+  describe file('/usr/share/xsessions/ubuntu.desktop') do
+    its(:content) { should match('Exec=gnome-session') }
+  end
+
+  describe command('gnome-session --version') do
+    its(:exit_status) { should eq 0 }
+  end
+
+end


### PR DESCRIPTION
Addressing https://github.com/cargomedia/puppet-cargomedia/issues/1148

This will remove any unmanaged xsession configurations.
So the unity entry will be removed from the greeter, to avoid confusion.
I think we don't need unity. If we need it, we can start it manually with `gnome-session --session=ubuntu`.

@kris-lab wdyt?