### PR TITLE
ffmpeg-cm and janus conflicting

### DIFF
--- a/modules/ffmpeg/manifests/init.pp
+++ b/modules/ffmpeg/manifests/init.pp
@@ -1,8 +1,16 @@
 class ffmpeg {
 
-  require 'apt::source::cargomedia'
 
-  package { 'ffmpeg-cm':
+  if $::lsbdistcodename == 'jessie' {
+    require 'apt::source::backports'
+    $package_name = 'ffmpeg'
+  } else {
+    require 'apt::source::cargomedia'
+    $package_name = 'ffmpeg-cm'
+  }
+
+  package { $package_name:
     provider => 'apt',
+    ensure   => present,
   }
 }

--- a/modules/ffmpeg/metadata.json
+++ b/modules/ffmpeg/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "cargomedia-ffmpeg",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Cargo Media",
   "license": "MIT",
   "summary": "ffmpeg",

--- a/modules/ffmpeg/spec/default/spec.rb
+++ b/modules/ffmpeg/spec/default/spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe 'ffmpeg' do
 
-  describe package('ffmpeg-cm') do
-    it { should be_installed }
-  end
-
   describe command('/usr/bin/ffmpeg -version') do
     its(:exit_status) { should eq 0 }
   end

--- a/modules/mjr_convert/metadata.json
+++ b/modules/mjr_convert/metadata.json
@@ -8,7 +8,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["7"]
+      "operatingsystemrelease": ["7", "8"]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Only on jessie. To reproduce:
- install cargomedia apt sources (e.g. with test `spec:apt:source:cargomedia`)
- ssh into VM

#### Variant 1
- `apt-get install janus`

Now `apt-get install ffmpeg-cm` fails:
```
[..]
Unpacking ffmpeg-cm (7:2.8.6-jessie1) ...
dpkg: error processing archive /var/cache/apt/archives/ffmpeg-cm_7%3a2.8.6-jessie1_amd64.deb (--unpack):
 trying to overwrite '/usr/lib/x86_64-linux-gnu/libavcodec.so.56', which is also in package libavcodec56:amd64 6:11.6-1~deb8u1
Processing triggers for man-db (2.7.0.2-5) ...
Processing triggers for systemd (215-17+deb8u3) ...
Errors were encountered while processing:
 /var/cache/apt/archives/ffmpeg-cm_7%3a2.8.6-jessie1_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

#### Variant 2
- `apt-get install ffmpeg-cm`
- `apt-get install janus`
installs with failure (on cache):
```
[..]
Errors were encountered while processing:
 /var/cache/apt/archives/libavutil54_6%3a11.6-1~deb8u1_amd64.deb
 /var/cache/apt/archives/libavcodec56_6%3a11.6-1~deb8u1_amd64.deb
 /var/cache/apt/archives/libavformat56_6%3a11.6-1~deb8u1_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```
- re-try install
```
root@debian-8-amd64-default:/home/vagrant# apt-get install janus
Reading package lists... Done
Building dependency tree       
Reading state information... Done
janus is already the newest version.
You might want to run 'apt-get -f install' to correct these:
The following packages have unmet dependencies:
 janus : Depends: libavcodec56 (>= 6:11~beta1) but it is not going to be installed or
                  libavcodec-extra-56 (>= 6:11.6) but it is not going to be installed
         Depends: libavformat56 (>= 6:11~beta1) but it is not going to be installed
         Depends: libavutil54 (>= 6:11~beta1) but it is not going to be installed
 libavresample2 : Depends: libavutil54 (>= 6:11~beta1) but it is not going to be installed
```

`dpkg -l  libav*` returns packages installed with config files around (ideal is `ii`):
```
dpkg -l libav*
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                Version                Architecture           Description
+++-===================================-======================-======================-============================================================================
ii  libavahi-client3:amd64              0.6.31-5               amd64                  Avahi client library
ii  libavahi-common-data:amd64          0.6.31-5               amd64                  Avahi common data files
ii  libavahi-common3:amd64              0.6.31-5               amd64                  Avahi common library
un  libavcodec-extra-56                 <none>                 <none>                 (no description available)
ic  libavcodec56:amd64                  6:11.6-1~deb8u1        amd64                  Libav codec library
ic  libavformat56:amd64                 6:11.6-1~deb8u1        amd64                  Libav file format library
un  libavresample0                      <none>                 <none>                 (no description available)
iU  libavresample2:amd64                6:11.6-1~deb8u1        amd64                  Libav audio resampling library
ic  libavutil54:amd64                   6:11.6-1~deb8u1        amd64                  Libav utility library
````