### PR TITLE
Don't install "latest" for gst plugins

### DIFF
--- a/modules/gstreamer/manifests/plugins/bad.pp
+++ b/modules/gstreamer/manifests/plugins/bad.pp
@@ -1,12 +1,9 @@
-class gstreamer::plugins::bad (
-  $version = 'present',
-) {
+class gstreamer::plugins::bad {
 
   require 'apt::source::cargomedia'
   require 'gstreamer::plugins::base'
 
   package { 'gstreamer1.0-plugins-bad':
-    ensure => $version,
     provider => 'apt',
   }
 }

--- a/modules/gstreamer/manifests/plugins/bad.pp
+++ b/modules/gstreamer/manifests/plugins/bad.pp
@@ -1,5 +1,5 @@
 class gstreamer::plugins::bad (
-  $version = 'latest',
+  $version = 'present',
 ) {
 
   require 'apt::source::cargomedia'

--- a/modules/gstreamer/manifests/plugins/base.pp
+++ b/modules/gstreamer/manifests/plugins/base.pp
@@ -1,11 +1,8 @@
-class gstreamer::plugins::base (
-  $version = 'present',
-) {
+class gstreamer::plugins::base {
 
   require 'apt::source::cargomedia'
 
   package { 'gstreamer1.0-plugins-base':
-    ensure => $version,
     provider => 'apt',
   }
 }

--- a/modules/gstreamer/manifests/plugins/base.pp
+++ b/modules/gstreamer/manifests/plugins/base.pp
@@ -1,5 +1,5 @@
 class gstreamer::plugins::base (
-  $version = 'latest',
+  $version = 'present',
 ) {
 
   require 'apt::source::cargomedia'

--- a/modules/gstreamer/manifests/plugins/entrans.pp
+++ b/modules/gstreamer/manifests/plugins/entrans.pp
@@ -1,12 +1,9 @@
-class gstreamer::plugins::entrans (
-  $version = 'present',
-) {
+class gstreamer::plugins::entrans {
 
   require 'apt::source::cargomedia'
   require 'gstreamer::plugins::base'
 
   package { 'gst-entrans':
-    ensure => $version,
     provider => 'apt',
   }
 }

--- a/modules/gstreamer/manifests/plugins/entrans.pp
+++ b/modules/gstreamer/manifests/plugins/entrans.pp
@@ -1,5 +1,5 @@
 class gstreamer::plugins::entrans (
-  $version = 'latest',
+  $version = 'present',
 ) {
 
   require 'apt::source::cargomedia'

--- a/modules/gstreamer/manifests/plugins/good.pp
+++ b/modules/gstreamer/manifests/plugins/good.pp
@@ -1,5 +1,5 @@
 class gstreamer::plugins::good (
-  $version = 'latest',
+  $version = 'present',
 ) {
 
   require 'apt::source::cargomedia'

--- a/modules/gstreamer/manifests/plugins/good.pp
+++ b/modules/gstreamer/manifests/plugins/good.pp
@@ -1,12 +1,9 @@
-class gstreamer::plugins::good (
-  $version = 'present',
-) {
+class gstreamer::plugins::good {
 
   require 'apt::source::cargomedia'
   require 'gstreamer::plugins::base'
 
   package { 'gstreamer1.0-plugins-good':
-    ensure => $version,
     provider => 'apt',
   }
 }

--- a/modules/gstreamer/manifests/plugins/libav.pp
+++ b/modules/gstreamer/manifests/plugins/libav.pp
@@ -1,5 +1,5 @@
 class gstreamer::plugins::libav (
-  $version = 'latest',
+  $version = 'present',
 ) {
 
   require 'apt::source::cargomedia'

--- a/modules/gstreamer/manifests/plugins/libav.pp
+++ b/modules/gstreamer/manifests/plugins/libav.pp
@@ -1,12 +1,9 @@
-class gstreamer::plugins::libav (
-  $version = 'present',
-) {
+class gstreamer::plugins::libav {
 
   require 'apt::source::cargomedia'
   require 'gstreamer::plugins::base'
 
   package { 'gstreamer1.0-libav':
-    ensure => $version,
     provider => 'apt',
   }
 }

--- a/modules/gstreamer/manifests/plugins/ugly.pp
+++ b/modules/gstreamer/manifests/plugins/ugly.pp
@@ -1,12 +1,9 @@
-class gstreamer::plugins::ugly (
-  $version = 'present',
-) {
+class gstreamer::plugins::ugly {
 
   require 'apt::source::cargomedia'
   require 'gstreamer::plugins::base'
 
   package { 'gstreamer1.0-plugins-ugly':
-    ensure => $version,
     provider => 'apt',
   }
 }

--- a/modules/gstreamer/manifests/plugins/ugly.pp
+++ b/modules/gstreamer/manifests/plugins/ugly.pp
@@ -1,5 +1,5 @@
 class gstreamer::plugins::ugly (
-  $version = 'latest',
+  $version = 'present',
 ) {
 
   require 'apt::source::cargomedia'

--- a/modules/gstreamer/manifests/tools.pp
+++ b/modules/gstreamer/manifests/tools.pp
@@ -1,5 +1,5 @@
 class gstreamer::tools(
-  $version = 'latest',
+  $version = 'present',
 ) {
 
   require 'apt::source::cargomedia'

--- a/modules/gstreamer/manifests/tools.pp
+++ b/modules/gstreamer/manifests/tools.pp
@@ -1,11 +1,8 @@
-class gstreamer::tools(
-  $version = 'present',
-) {
+class gstreamer::tools {
 
   require 'apt::source::cargomedia'
 
   package { 'gstreamer1.0-tools':
-    ensure => $version,
     provider => 'apt',
   }
 }


### PR DESCRIPTION
@kris-lab @ppp0 currently we install the "latest" gst plugin DEBs.

Should we change that, to have finer control over upgrades?