### PR TITLE
Upgrade Node.js to v5.x

### DIFF
--- a/modules/nodejs/manifests/init.pp
+++ b/modules/nodejs/manifests/init.pp
@@ -4,8 +4,8 @@ class nodejs {
 
   apt::source { 'nodesource':
     entries => [
-      "deb https://deb.nodesource.com/node_0.12 ${::lsbdistcodename} main",
-      "deb-src https://deb.nodesource.com/node_0.12 ${::lsbdistcodename} main",
+      "deb https://deb.nodesource.com/node_5.x ${::lsbdistcodename} main",
+      "deb-src https://deb.nodesource.com/node_5.x ${::lsbdistcodename} main",
     ],
     keys    => {
       'nodesource' => {

--- a/modules/nodejs/metadata.json
+++ b/modules/nodejs/metadata.json
@@ -8,7 +8,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["7"]
+      "operatingsystemrelease": ["7", "8"]
     }
   ],
   "dependencies": [

--- a/modules/nodejs/spec/init/spec.rb
+++ b/modules/nodejs/spec/init/spec.rb
@@ -8,7 +8,7 @@ describe 'nodejs' do
 
   describe command('nodejs -v') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match /v0\.12\./}
+    its(:stdout) { should match /v5\./}
   end
 
   describe command('node -v') do


### PR DESCRIPTION
From 0.12

Used by:
- autoprefixer
- bower
- browserify
- cm-janus
- less
- pulsar-rest-api
- socket-redis
- uglify

@vogdb fyi