### PR TITLE
Run "vagrant plugin install" in home dir

### DIFF
--- a/modules/vagrant/manifests/plugin.pp
+++ b/modules/vagrant/manifests/plugin.pp
@@ -20,5 +20,6 @@ define vagrant::plugin(
     path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     unless      => "vagrant plugin list | grep -w '${listOutput}'",
     environment => ["HOME=${user_home}"],   # Vagrant needs $HOME (https://github.com/mitchellh/vagrant/issues/2215)
+    cwd         => $user_home,
   }
 }


### PR DESCRIPTION
@ppp0 please review

The process writes/reads to/from CWD it seems, so fails if it's /root.