### PR TITLE
Add shell script to shut down and delete all virtualbox VMs

### DIFF
--- a/modules/virtualbox/manifests/init.pp
+++ b/modules/virtualbox/manifests/init.pp
@@ -24,4 +24,13 @@ class virtualbox {
     ensure   => present,
     provider => 'apt',
   }
+
+  file { '/usr/local/bin/deleteAllVirtualboxVms':
+    ensure  => file,
+    content => template("${module_name}/deleteAllVirtualboxVms.sh"),
+    group   => '0',
+    owner   => '0',
+    mode    => '0755',
+  }
+
 }

--- a/modules/virtualbox/spec/default/spec.rb
+++ b/modules/virtualbox/spec/default/spec.rb
@@ -6,4 +6,9 @@ describe 'virtualbox' do
     its(:exit_status) { should eq 0 }
   end
 
+  describe file('/usr/local/bin/deleteAllVirtualboxVms') do
+    it { should be_file }
+    it { should be_executable }
+  end
+
 end

--- a/modules/virtualbox/templates/deleteAllVirtualboxVms.sh
+++ b/modules/virtualbox/templates/deleteAllVirtualboxVms.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+if [ $# -lt 1 ]; then
+  echo "USAGE: $0 <user>"
+  exit 1
+fi
+
+user=$1
+vboxmanage="sudo -u ${user} VBoxManage"
+
+listVms() {
+  echo 'VMs:'
+  echo '===='
+  ${vboxmanage} list vms
+  echo '===='
+}
+
+listVms
+
+echo 'Shutting down VMs…'
+${vboxmanage} list runningvms | awk '{print $2;}' | xargs -I vmid ${vboxmanage} controlvm vmid poweroff
+
+echo 'Unregistering VMs…'
+${vboxmanage} list vms | awk '{print $2;}' | xargs -I vmid ${vboxmanage} unregistervm vmid --delete
+
+listVms


### PR DESCRIPTION
@kris-lab please review
@ppp0 fyi

When we stop builds manually sometimes we end up with "zombie" VMs on CI.
The only reliable way to stop and delete them is to use `VBoxManage`. `vagrant global-status` does not necessarily see them.
This script should shut down and delete all VMs.
Use carefully.