### PR TITLE
Add ScreenConnect

### DIFF
--- a/modules/elasticsearch/manifests/init.pp
+++ b/modules/elasticsearch/manifests/init.pp
@@ -5,7 +5,7 @@ class elasticsearch (
 ) {
 
   require 'apt'
-  require 'java'
+  require 'java::jre_headless'
 
   $version = '1.3.1'
 

--- a/modules/java/manifests/jre.pp
+++ b/modules/java/manifests/jre.pp
@@ -1,0 +1,10 @@
+class java::jre {
+
+  require 'apt'
+
+  package { 'openjdk-7-jre':
+    ensure   => present,
+    provider => 'apt',
+  }
+
+}

--- a/modules/java/manifests/jre_headless.pp
+++ b/modules/java/manifests/jre_headless.pp
@@ -1,4 +1,4 @@
-class java {
+class java::jre_headless {
 
   require 'apt'
 
@@ -6,4 +6,5 @@ class java {
     ensure   => present,
     provider => 'apt',
   }
+
 }

--- a/modules/java/metadata.json
+++ b/modules/java/metadata.json
@@ -8,7 +8,15 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["7"]
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "15.04"
+      ]
     }
   ],
   "dependencies": [

--- a/modules/java/spec/init/manifest.pp
+++ b/modules/java/spec/init/manifest.pp
@@ -1,4 +1,0 @@
-node default {
-
-  class { 'java': }
-}

--- a/modules/java/spec/jre/manifest.pp
+++ b/modules/java/spec/jre/manifest.pp
@@ -1,0 +1,5 @@
+node default {
+
+  class { 'java::jre': }
+
+}

--- a/modules/java/spec/jre/spec.rb
+++ b/modules/java/spec/jre/spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'java' do
+describe 'java::jre' do
 
   describe command('java -version') do
     its(:exit_status) { should eq 0 }
@@ -9,4 +9,5 @@ describe 'java' do
   describe command('ls -d /usr/lib/jvm/java-7-openjdk*') do
     its(:exit_status) { should eq 0 }
   end
+
 end

--- a/modules/java/spec/jre_headless/manifest.pp
+++ b/modules/java/spec/jre_headless/manifest.pp
@@ -1,0 +1,5 @@
+node default {
+
+  class { 'java::jre_headless': }
+
+}

--- a/modules/java/spec/jre_headless/spec.rb
+++ b/modules/java/spec/jre_headless/spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'java::jre_headless' do
+
+  describe command('java -version') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe command('ls -d /usr/lib/jvm/java-7-openjdk*') do
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/modules/jenkins/manifests/common.pp
+++ b/modules/jenkins/manifests/common.pp
@@ -1,7 +1,7 @@
 class jenkins::common {
 
   include 'ntp'
-  include 'java'
+  include 'java::jre_headless'
 
   user { 'jenkins':
     ensure     => present,

--- a/modules/screenconnect/Puppetfile
+++ b/modules/screenconnect/Puppetfile
@@ -1,0 +1,11 @@
+mod 'cargomedia/apt',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/apt'
+
+mod 'cargomedia/helper',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/helper'
+
+mod 'cargomedia/java',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/java'

--- a/modules/screenconnect/manifests/init.pp
+++ b/modules/screenconnect/manifests/init.pp
@@ -1,0 +1,19 @@
+class screenconnect(
+  $machine_name = $::clientcert,
+  $account,
+  $server,
+  $key
+) {
+
+  require 'java::jre'
+
+  $port = 443
+  $deb_url = "https://${account}.screenconnect.com/Bin/ScreenConnect.ClientSetup.deb?h=${server}&p=${port}&k=${key}&e=Access&y=Guest&t=${machine_name}"
+
+  helper::script { 'install screenconnect':
+    content => template("${module_name}/install.sh.erb"),
+    unless  => 'dpkg -l screenconnect-*',
+    require => Class['apt::update'],
+  }
+
+}

--- a/modules/screenconnect/metadata.json
+++ b/modules/screenconnect/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "cargomedia-screenconnect",
+  "version": "0.0.1",
+  "author": "Cargo Media",
+  "license": "MIT",
+  "summary": "screenconnect.com",
+  "source": "https://github.com/cargomedia/puppet-packages",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "15.04"
+      ]
+    }
+  ],
+  "dependencies": [
+  ]
+}

--- a/modules/screenconnect/spec/default/manifest.pp
+++ b/modules/screenconnect/spec/default/manifest.pp
@@ -1,0 +1,9 @@
+node default {
+
+  class { 'screenconnect':
+    account => 'cargomedia',
+    server  => 'myInstanceServer.screenconnect.com',
+    key     => 'mySecretKey',
+  }
+
+}

--- a/modules/screenconnect/spec/default/spec.rb
+++ b/modules/screenconnect/spec/default/spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'screenconnect' do
+
+  describe process('java') do
+    its(:args) { should match('-classpath /opt/screenconnect-') }
+  end
+
+end

--- a/modules/screenconnect/templates/install.sh.erb
+++ b/modules/screenconnect/templates/install.sh.erb
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+curl -sL '<%= @deb_url %>' > screenconnect.deb
+dpkg -i --force-confold screenconnect.deb

--- a/modules/wowza/manifests/init.pp
+++ b/modules/wowza/manifests/init.pp
@@ -5,7 +5,7 @@ class wowza (
   $admin_password = 'root'
 ) {
 
-  require 'java'
+  require 'java::jre_headless'
   require 'ffmpeg'
 
   include 'wowza::service'


### PR DESCRIPTION
see https://github.com/cargomedia/puppet-packages-ubuntu/issues/14

[Update ppp0 24/11/15]

#### Installing screenconnect
* Log in to https://cargomedia.screenconnect.com
* Go to "Host" section, "Access", click on the plus sign, download the correct client for OS
* Copy (eg, `scp`) the `deb` file
* Install java dependency
```
sudo apt-get install default-jre
```
* Install screenconnect agent
```
dpkg -i ScreenConnect.ClientSetup.deb
```
* Set up your other client, connect, enjoy


See https://github.com/cargomedia/puppet-cargomedia/blob/master/docu/bulldog/setup.md#installing-screenconnect-remote-access