### PR TITLE
Make accountsservice spec reliable

### DIFF
--- a/modules/accountsservice/manifests/init.pp
+++ b/modules/accountsservice/manifests/init.pp
@@ -6,11 +6,5 @@ class accountsservice {
     ensure   => present,
     provider => 'apt',
   }
-  ~>
-
-  exec { 'wait for dbus reload':
-    command     => '/bin/sleep 10',
-    refreshonly => true,
-  }
 
 }

--- a/modules/accountsservice/manifests/user.pp
+++ b/modules/accountsservice/manifests/user.pp
@@ -9,14 +9,22 @@ define accountsservice::user(
     User[$user] -> Accountsservice::User[$title]
   }
 
-  $connection_name = 'org.freedesktop.Accounts'
-  $object_path = "/org/freedesktop/Accounts/User$(id -u ${user})"
+  # Find user before calling "SetXSession", to make sure it is created
+  $find_user = "dbus-send --system --type=method_call --print-reply --dest=org.freedesktop.Accounts /org/freedesktop/Accounts org.freedesktop.Accounts.FindUserByName string:\"${user}\""
+  exec { "find user ${user}":
+    path      => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    command   => $find_user,
+    unless    => $find_user,
+  }
 
+  $xsession_set = "dbus-send --system --type=method_call --print-reply --dest=org.freedesktop.Accounts /org/freedesktop/Accounts/User$(id -u ${user}) org.freedesktop.Accounts.User.SetXSession string:\"${xsession}\""
+  $xsession_get = "dbus-send --system --type=method_call --print-reply --dest=org.freedesktop.Accounts /org/freedesktop/Accounts/User$(id -u ${user}) org.freedesktop.DBus.Properties.Get string:\"org.freedesktop.Accounts.User\" string:\"XSession\""
   exec { "set default xsession for user ${user}":
     path     => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     provider => shell,
-    command  => "dbus-send --system --type=method_call --print-reply --dest=${$connection_name} ${object_path} org.freedesktop.Accounts.User.SetXSession string:\"${xsession}\"",
-    unless   => "dbus-send --system --type=method_call --print-reply --dest=${$connection_name} ${object_path} org.freedesktop.DBus.Properties.Get string:\"org.freedesktop.Accounts.User\" string:\"XSession\" | grep 'string \"${xsession}\"'",
+    command  => $xsession_set,
+    unless   => "${xsession_get} | grep 'string \"${xsession}\"'",
+    require  => Exec["find user ${user}"],
   }
 
 }


### PR DESCRIPTION
@kris-lab please review

The trick seems to be that one has to *request/find* a user first, before setting any configuration on it