### PR TITLE
HID Multitouch

### DIFF
--- a/modules/xorg/manifests/config/multitouch.pp
+++ b/modules/xorg/manifests/config/multitouch.pp
@@ -1,0 +1,35 @@
+class xorg::config::multitouch (
+  $config_name = '50-multitouch'
+){
+
+  require 'apt'
+
+  package { 'xserver-xorg-input-multitouch':
+    ensure   => present,
+    provider => 'apt',
+  }
+
+  xorg::config { 'multitouch support - definition':
+    section     => 'InputClass',
+    key         => 'MatchIsTouchpad',
+    value       => true,
+    config_name => $config_name,
+    require     => Package['xserver-xorg-input-multitouch'],
+  }
+
+  xorg::config { 'multitouch support - identifier':
+    section     => 'InputClass',
+    key         => 'Identifier',
+    value       => 'Multitouch Touchpad',
+    config_name => $config_name,
+    require     => Package['xserver-xorg-input-multitouch'],
+  }
+
+  xorg::config { 'multitouch support - driver':
+    section     => 'InputClass',
+    key         => 'Driver',
+    value       => 'hid-multitouch',
+    config_name => $config_name,
+    require     => Package['xserver-xorg-input-multitouch'],
+  }
+}

--- a/modules/xorg/spec/config_multitouch/manfiest.pp
+++ b/modules/xorg/spec/config_multitouch/manfiest.pp
@@ -1,0 +1,4 @@
+node default {
+  class { 'xorg::config::multitouch':
+  }
+}

--- a/modules/xorg/spec/config_multitouch/spec.rb
+++ b/modules/xorg/spec/config_multitouch/spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'xorg::config::multitouch' do
+
+  describe package('xserver-xorg-input-multitouch') do
+    it { should be_installed }
+  end
+
+  describe file('/etc/X11/xorg.conf.d/50-multitouch.conf') do
+    its(:content) { should match /Driver "hid-multitouch"/ }
+  end
+
+end


### PR DESCRIPTION
See https://github.com/cargomedia/puppet-cargomedia/blob/master/docu/bulldog/setup.md#install-hid-multitouch-drivers
```
sudo apt-get install xserver-xorg-input-multitouch
sed 's/Driver "multitouch"/Driver "hid-multitouch"/' /usr/share/X11/xorg.conf.d/50-multitouch.conf > tmp
mv tmp > /usr/share/X11/xorg.conf.d/50-multitouch.conf
```

Related to https://github.com/cargomedia/puppet-packages/issues/1272 (Xorg)

---
@kris-lab notes
- http://askubuntu.com/a/27017