### PR TITLE
Decklink / Blackmagic Driver

### DIFF
--- a/modules/blackmagic/Puppetfile
+++ b/modules/blackmagic/Puppetfile
@@ -1,0 +1,15 @@
+mod 'cargomedia/apt',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/apt'
+
+mod 'cargomedia/kernel',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/kernel'
+
+mod 'cargomedia/helper',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/helper'
+
+mod 'cargomedia/monit',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/monit'

--- a/modules/blackmagic/manifests/desktopvideo.pp
+++ b/modules/blackmagic/manifests/desktopvideo.pp
@@ -10,11 +10,12 @@ class blackmagic::desktopvideo {
     provider => 'apt',
   }
 
-  $url = 'http://puppet-packages.cargomedia.ch/blackmagic/Blackmagic_Desktop_Video_Linux_10.6.2.tar.gz'
+  $deb_url = 'http://puppet-packages.cargomedia.ch/blackmagic/desktopvideo_10.6.2a3_amd64.deb'
 
   helper::script { 'install blackmagic desktopvideo':
     content => template("${module_name}/desktopvideo/install.sh.erb"),
     unless  => "dpkg-query -f '\${Status} \${Version}\n' -W desktopvideo | grep -q 'ok installed ${version}'",
+    timeout => 1000,
     require => [
       Class['apt::update'],
       Class['kernel::headers'],

--- a/modules/blackmagic/manifests/desktopvideo.pp
+++ b/modules/blackmagic/manifests/desktopvideo.pp
@@ -1,0 +1,40 @@
+class blackmagic::desktopvideo {
+
+  $version = '10.6.2a3'
+
+  include 'apt'
+  include 'kernel::headers'
+
+  package { ['libgl1-mesa-glx']:
+    ensure   => present,
+    provider => 'apt',
+  }
+
+  $url = 'http://puppet-packages.cargomedia.ch/blackmagic/Blackmagic_Desktop_Video_Linux_10.6.2.tar.gz'
+
+  helper::script { 'install blackmagic desktopvideo':
+    content => template("${module_name}/desktopvideo/install.sh.erb"),
+    unless  => "dpkg-query -f '\${Status} \${Version}\n' -W desktopvideo | grep -q 'ok installed ${version}'",
+    require => [
+      Class['apt::update'],
+      Class['kernel::headers'],
+      Package['libgl1-mesa-glx'],
+    ]
+  }
+
+  file { 'blackmagic-firmware-status':
+    ensure  => file,
+    path    => '/usr/local/bin/blackmagic-firmware-status',
+    content => template("${module_name}/desktopvideo/firmware-status.sh"),
+    owner   => '0',
+    group   => '0',
+    mode    => '0755',
+    require => Helper::Script['install blackmagic desktopvideo'],
+  }
+
+  @monit::entry { 'blackmagic-firmware-status':
+    content => template("${module_name}/desktopvideo/firmware-status-monit.conf"),
+    require => File['blackmagic-firmware-status'],
+  }
+
+}

--- a/modules/blackmagic/metadata.json
+++ b/modules/blackmagic/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "cargomedia-blackmagic",
+  "version": "0.0.1",
+  "author": "Cargo Media",
+  "license": "MIT",
+  "summary": "blackmagic",
+  "source": "https://github.com/cargomedia/puppet-packages",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "15.04"
+      ]
+    }
+  ],
+  "dependencies": [
+  ]
+}

--- a/modules/blackmagic/spec/desktopvideo/manifest.pp
+++ b/modules/blackmagic/spec/desktopvideo/manifest.pp
@@ -1,0 +1,8 @@
+node default {
+
+  require 'monit'
+
+  class { 'blackmagic::desktopvideo':
+  }
+
+}

--- a/modules/blackmagic/spec/desktopvideo/spec.rb
+++ b/modules/blackmagic/spec/desktopvideo/spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'blackmagic::desktopvideo' do
+
+  describe package('desktopvideo') do
+    it { should be_installed }
+  end
+
+  describe kernel_module('blackmagic') do
+    it { should be_loaded }
+  end
+
+  describe kernel_module('blackmagic_io') do
+    it { should be_loaded }
+  end
+
+  describe command('monit summary') do
+    its(:stdout) { should match /'blackmagic-firmware-status'.*Status ok/ }
+  end
+
+end

--- a/modules/blackmagic/templates/desktopvideo/firmware-status-monit.conf
+++ b/modules/blackmagic/templates/desktopvideo/firmware-status-monit.conf
@@ -1,0 +1,2 @@
+check program blackmagic-firmware-status path /usr/local/bin/blackmagic-firmware-status
+  if status != 0 then alert

--- a/modules/blackmagic/templates/desktopvideo/firmware-status.sh
+++ b/modules/blackmagic/templates/desktopvideo/firmware-status.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+BlackmagicFirmwareUpdater status | cut -f4 | xargs -I status test "status" = "OK"

--- a/modules/blackmagic/templates/desktopvideo/install.sh.erb
+++ b/modules/blackmagic/templates/desktopvideo/install.sh.erb
@@ -1,5 +1,4 @@
 #!/bin/bash -e
 
-curl -sL '<%= @url %>' | tar -xzf -
-cd Blackmagic_Desktop_Video_Linux_*
-dpkg -i --force-confold deb/amd64/desktopvideo_*_amd64.deb
+curl -sL '<%= @deb_url %>' > desktopvideo.deb
+dpkg -i --force-confold desktopvideo.deb

--- a/modules/blackmagic/templates/desktopvideo/install.sh.erb
+++ b/modules/blackmagic/templates/desktopvideo/install.sh.erb
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+curl -sL '<%= @url %>' | tar -xzf -
+cd Blackmagic_Desktop_Video_Linux_*
+dpkg -i --force-confold deb/amd64/desktopvideo_*_amd64.deb

--- a/modules/kernel/manifests/headers.pp
+++ b/modules/kernel/manifests/headers.pp
@@ -1,0 +1,8 @@
+class kernel::headers {
+
+  package { "linux-headers-${::kernelrelease}":
+    ensure   => present,
+    provider => 'apt',
+  }
+
+}

--- a/modules/kernel/metadata.json
+++ b/modules/kernel/metadata.json
@@ -8,11 +8,16 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["7"]
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": ["15.04"]
+      "operatingsystemrelease": [
+        "15.04"
+      ]
     }
   ],
   "dependencies": [

--- a/modules/kernel/spec/headers/manifest.pp
+++ b/modules/kernel/spec/headers/manifest.pp
@@ -1,0 +1,6 @@
+node default {
+
+  class { 'kernel::headers' :
+  }
+
+}

--- a/modules/kernel/spec/headers/spec.rb
+++ b/modules/kernel/spec/headers/spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'kernel::headers' do
+
+  describe command('test -d /lib/modules/$(uname -r)/build/include') do
+    its(:exit_status) { should eq 0 }
+  end
+
+end


### PR DESCRIPTION
See https://github.com/cargomedia/puppet-cargomedia/blob/master/docu/bulldog/setup.md#decklink-blackmagic-studio-drivers

version:        10.6.2a3

```sh
wget http://sw.blackmagicdesign.com/DesktopVideo/v10.5/Blackmagic_Desktop_Video_Linux_10.5.tar.gz
tar -xvf Blackmagic_Desktop_Video_Linux_10.5.tar.gz
cd Blackmagic_Desktop_Video_Linux_10.5
sudo dpkg -i desktopvideo_*.deb
#
modprobe blackmagic
modprobe blackmagic_io

#### Verify kernel modules have loaded
#
lsmod | grep blackmagic

# blackmagic            585728  0
# blackmagic_io         430080  1

# Verify dev entries for Card
ls /dev/blackmagic/*
# io0  ttyio0

# Check Firmware and Upgrade if necessary
#
/usr/bin/BlackmagicFirmwareUpdater status
# 0:  /dev/blackmagic/io0 [DeckLink Studio 4K]  0x7d    OK
#
#
/usr/bin/BlackmagicFirmwareUpdater update /dev/blackmagic/io0
# /dev/blackmagic/io0 firmware update completed successfully.
# Please reboot your system now to activate new firmware
```