### PR TITLE
Add phantomjs module

### DIFF
--- a/modules/phantomjs/Puppetfile
+++ b/modules/phantomjs/Puppetfile
@@ -1,11 +1,6 @@
+mod 'puppetlabs/stdlib',
+  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+
 mod 'cargomedia/helper',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/helper
-
-mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
-  :path => 'modules/apt'
-
-mod 'cargomedia/build',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
-  :path => 'modules/build'

--- a/modules/phantomjs/Puppetfile
+++ b/modules/phantomjs/Puppetfile
@@ -1,0 +1,11 @@
+mod 'cargomedia/helper',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/helper
+
+mod 'cargomedia/apt',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/apt'
+
+mod 'cargomedia/build',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/build'

--- a/modules/phantomjs/Puppetfile
+++ b/modules/phantomjs/Puppetfile
@@ -3,4 +3,8 @@ mod 'puppetlabs/stdlib',
 
 mod 'cargomedia/helper',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
-  :path => 'modules/helper
+  :path => 'modules/helper'
+
+mod 'cargomedia/apt',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/apt'

--- a/modules/phantomjs/manifests/init.pp
+++ b/modules/phantomjs/manifests/init.pp
@@ -1,12 +1,6 @@
 class phantomjs($version = '2.1.1') {
 
-  require 'apt'
-  require 'build'
-
-  package {['unp', 'fontconfig']:
-    provider => 'apt',
-  }
-  ->
+  ensure_packages(['fontconfig'])
 
   helper::script { 'install phantomjs':
     content => template("${module_name}/install.sh"),

--- a/modules/phantomjs/manifests/init.pp
+++ b/modules/phantomjs/manifests/init.pp
@@ -1,0 +1,21 @@
+class phantomjs($version = '2.1.1') {
+
+  require 'apt'
+  require 'build'
+
+  package {['unp', 'fontconfig']:
+    provider => 'apt',
+  }
+  ->
+
+  helper::script { 'install phantomjs':
+    content => template("${module_name}/install.sh"),
+    unless  => "/usr/local/share/phantomjs/bin/phantomjs --version | grep -q '${version}'",
+  }
+  ->
+
+  file { '/usr/local/bin/phantomjs':
+    ensure    => link,
+    target    => '/usr/local/share/phantomjs/bin/phantomjs',
+  }
+}

--- a/modules/phantomjs/manifests/init.pp
+++ b/modules/phantomjs/manifests/init.pp
@@ -1,6 +1,8 @@
 class phantomjs($version = '2.1.1') {
 
-  ensure_packages(['fontconfig'])
+  include 'apt'
+
+  ensure_packages(['fontconfig'], {provider => 'apt'})
 
   helper::script { 'install phantomjs':
     content => template("${module_name}/install.sh"),

--- a/modules/phantomjs/metadata.json
+++ b/modules/phantomjs/metadata.json
@@ -1,0 +1,16 @@
+{
+  "name": "cargomedia-phantomjs",
+  "version": "0.0.1",
+  "author": "Cargo Media",
+  "license": "MIT",
+  "summary": "phantomjs",
+  "source": "https://github.com/cargomedia/puppet-packages",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": ["7", "8"]
+    }
+  ],
+  "dependencies": [
+  ]
+}

--- a/modules/phantomjs/spec/init/manifest.pp
+++ b/modules/phantomjs/spec/init/manifest.pp
@@ -1,0 +1,4 @@
+node default {
+
+  class { 'phantomjs': }
+}

--- a/modules/phantomjs/spec/init/spec.rb
+++ b/modules/phantomjs/spec/init/spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'phantomjs' do
+
+  describe command('phantomjs --version') do
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/modules/phantomjs/templates/install.sh
+++ b/modules/phantomjs/templates/install.sh
@@ -2,6 +2,6 @@
 
 PHANTOMJS='phantomjs-<%= @version %>-linux-x86_64'
 curl -L https://bitbucket.org/ariya/phantomjs/downloads/${PHANTOMJS}.tar.bz2 > ${PHANTOMJS}
-unp ${PHANTOMJS}
+tar xjf ${PHANTOMJS}
 mv ${PHANTOMJS} phantomjs
 mv phantomjs /usr/local/share/

--- a/modules/phantomjs/templates/install.sh
+++ b/modules/phantomjs/templates/install.sh
@@ -4,4 +4,5 @@ PHANTOMJS='phantomjs-<%= @version %>-linux-x86_64'
 curl -L https://bitbucket.org/ariya/phantomjs/downloads/${PHANTOMJS}.tar.bz2 > ${PHANTOMJS}
 tar xjf ${PHANTOMJS}
 mv ${PHANTOMJS} phantomjs
+rm -rf /usr/local/share/phantomjs
 mv phantomjs /usr/local/share/

--- a/modules/phantomjs/templates/install.sh
+++ b/modules/phantomjs/templates/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+PHANTOMJS='phantomjs-<%= @version %>-linux-x86_64'
+curl -L https://bitbucket.org/ariya/phantomjs/downloads/${PHANTOMJS}.tar.bz2 > ${PHANTOMJS}
+unp ${PHANTOMJS}
+mv ${PHANTOMJS} phantomjs
+mv phantomjs /usr/local/share/


### PR DESCRIPTION
To run QUnit tests (https://github.com/cargomedia/cm/pull/2140), we need to have [phamtomjs][phantomjs] installed in dev and CI env.

Some inspiration: https://forge.puppet.com/3fs/phantomjs

[phantomjs]: http://phantomjs.org