### PR TITLE
Spec rake tasks interrupted on invalid JSON output

### DIFF
--- a/spec/lib/spec_runner.rb
+++ b/spec/lib/spec_runner.rb
@@ -131,20 +131,27 @@ module PuppetModules
 
       attr_reader :description, :stdout
 
+      # @param [String] description
+      # @param [TrueClass, FalseClass] success
+      # @param [String] summary
       def initialize(description, success, summary)
         @description = description
         @success = success
         @summary = summary
       end
 
+      # @return [TrueClass, FalseClass]
       def success?
         @success === true
       end
 
+      # @return [String]
       def summary
         @description + "\n" + @summary
       end
 
+      # @param [String] stdout
+      # @return [ExampleResult]
       def self.from_stdout(stdout)
         description = stdout['full_description']
         summary_lines = []
@@ -205,13 +212,12 @@ module PuppetModules
       end
       process_result = process.run
 
-      success = (process_result.status === 0)
-      spec_result = SpecResult.new(box, success)
+      spec_result = SpecResult.new(box, process_result.success?)
       begin
         stdout = JSON.parse(process_result.stdout.lines.to_a.last)
       rescue Exception => e
         spec_result.success = false
-        spec_result.summary = "#{e.message}\nStdout:\n`#{process_result.stdout}`"
+        spec_result.summary = "#{e.message}\nOutput:\n`#{process_result.output}`"
       else
         spec_result.duration = stdout['summary']['duration']
         spec_result.summary = stdout['summary']['summary_line']


### PR DESCRIPTION
It seems like if a spec returns invalid JSON, the whole test run is interrupted, because of a parsing error.
We should make sure to continue the test run (and fail the specific spec)?

@tomaszdurka can you look into this?

```
/var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/formatters/json_formatter.rb:50:in `encode': "\xC2" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/formatters/json_formatter.rb:50:in `to_json'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/formatters/json_formatter.rb:50:in `close'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:189:in `block in notify'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:188:in `each'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:188:in `notify'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:214:in `close'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:177:in `close_after'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:156:in `finish'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:79:in `report'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/bin/rspec:23:in `load'
	from /var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/bin/rspec:23:in `<main>'
rake aborted!
TypeError: can't convert nil into String
/var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/json_pure-1.8.3/lib/json/common.rb:155:in `initialize'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/json_pure-1.8.3/lib/json/common.rb:155:in `new'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/.bundle/vendor/ruby/1.9.1/gems/json_pure-1.8.3/lib/json/common.rb:155:in `parse'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/spec/lib/spec_runner.rb:86:in `initialize'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/spec/lib/spec_runner.rb:176:in `new'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/spec/lib/spec_runner.rb:176:in `run_spec_in_box'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/spec/lib/spec_runner.rb:154:in `block (2 levels) in run'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/spec/lib/spec_runner.rb:151:in `each'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/spec/lib/spec_runner.rb:151:in `block in run'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/spec/lib/spec_runner.rb:150:in `each'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/spec/lib/spec_runner.rb:150:in `run'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/Rakefile:29:in `execute'
/var/lib/jenkins/workspace/cargomedia-puppet-packages/Rakefile:40:in `block in <top (required)>'
```