### PR TITLE
Satis: send cron output to root, not to satis user

### DIFF
--- a/modules/satis/manifests/repo.pp
+++ b/modules/satis/manifests/repo.pp
@@ -1,4 +1,6 @@
-define satis::repo ($content) {
+define satis::repo (
+  $content,
+  $cron_environment = 'MAILTO=root') {
 
   require 'satis'
 
@@ -25,5 +27,6 @@ define satis::repo ($content) {
   cron { "cron satis repo ${name}":
     command => "/var/lib/satis/satis/bin/satis --no-interaction build ${specificationPath} ${outputPath} >/dev/null",
     user    => 'satis',
+    environment => $cron_environment,
   }
 }

--- a/modules/satis/spec/repo/spec.rb
+++ b/modules/satis/spec/repo/spec.rb
@@ -43,4 +43,8 @@ describe 'satis::repo' do
     its(:stderr) { should match /200 OK/}
     its(:stdout) { should match /foo Composer Repository/}
   end
+
+  describe file('/var/spool/cron/crontabs/satis') do
+    its(:content) { should match /MAILTO=root/ }
+  end
 end


### PR DESCRIPTION
For example there's a user "satis" and it has a cron job. If that cron job fails an email will be sent to the user, and forwarded to "satis@cargomedia.ch".

To receive such emails we should forward it to "root".

Maybe something like http://www.postfix.org/postconf.5.html#luser_relay

cc @kris-lab @ppp0 