### PR TITLE
Require "bzip2" for phantomjs

### DIFF
--- a/modules/phantomjs/manifests/init.pp
+++ b/modules/phantomjs/manifests/init.pp
@@ -3,7 +3,7 @@ class phantomjs($version = '2.1.7') {
   require 'nodejs'
   include 'apt'
 
-  ensure_packages(['fontconfig'], {provider => 'apt'})
+  ensure_packages(['fontconfig', 'bzip2'], {provider => 'apt'})
 
   package { 'phantomjs-prebuilt':
     ensure   => $version,


### PR DESCRIPTION
Used by the installer.
See also https://github.com/Medium/phantomjs/issues/267

@ppp0 please review