### PR TITLE
Audio incl. Bluetooth Audio

### DIFF
--- a/modules/bluetooth/Puppetfile
+++ b/modules/bluetooth/Puppetfile
@@ -1,0 +1,3 @@
+mod 'cargomedia/apt',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/apt'

--- a/modules/bluetooth/manifests/bluez.pp
+++ b/modules/bluetooth/manifests/bluez.pp
@@ -1,5 +1,7 @@
 class bluetooth::bluez {
 
+  require 'apt'
+
   package { ['bluez', 'bluez-alsa']:
     provider => apt,
   }

--- a/modules/bluetooth/manifests/bluez.pp
+++ b/modules/bluetooth/manifests/bluez.pp
@@ -1,0 +1,6 @@
+class bluetooth::bluez {
+
+  package { ['bluez', 'bluez-alsa', 'bluez-cups']:
+    provider => apt,
+  }
+}

--- a/modules/bluetooth/manifests/bluez.pp
+++ b/modules/bluetooth/manifests/bluez.pp
@@ -1,6 +1,6 @@
 class bluetooth::bluez {
 
-  package { ['bluez', 'bluez-alsa', 'bluez-cups']:
+  package { ['bluez', 'bluez-alsa']:
     provider => apt,
   }
 }

--- a/modules/bluetooth/manifests/init.pp
+++ b/modules/bluetooth/manifests/init.pp
@@ -12,7 +12,7 @@ class bluetooth (
   file { '/etc/bluetooth/audio.conf':
     ensure  => file,
     content => template("${module_name}/audio.conf"),
-    mode    => '0655',
+    mode    => '0644',
     owner   => '0',
     notify  => Service['bluetooth'],
     before  => Service['bluetooth'],

--- a/modules/bluetooth/manifests/init.pp
+++ b/modules/bluetooth/manifests/init.pp
@@ -3,6 +3,7 @@ class bluetooth (
   $audio_fastconnectable = true,
 ){
 
+  require 'apt'
   include 'bluetooth::bluez'
 
   package { 'bluetooth':

--- a/modules/bluetooth/manifests/init.pp
+++ b/modules/bluetooth/manifests/init.pp
@@ -1,0 +1,25 @@
+class bluetooth (
+  $audio_autoconnect = true,
+  $audio_fastconnectable = true,
+){
+
+  include 'bluetooth::bluez'
+
+  package { 'bluetooth':
+    provider => apt
+  }
+
+  file { '/etc/bluetooth/audio.conf':
+    ensure  => file,
+    content => template("${module_name}/audio.conf"),
+    mode    => '0655',
+    owner   => '0',
+    notify  => Service['bluetooth'],
+    before  => Service['bluetooth'],
+    require => Package['bluetooth'],
+  }
+
+  service { 'bluetooth':
+    enable => true,
+  }
+}

--- a/modules/bluetooth/metadata.json
+++ b/modules/bluetooth/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "cargomedia-bluetooth",
+  "version": "0.0.1",
+  "author": "Cargo Media",
+  "license": "MIT",
+  "summary": "bluetooth",
+  "source": "https://github.com/cargomedia/puppet-packages",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "15.04"
+      ]
+    }
+  ],
+  "dependencies": [
+  ]
+}

--- a/modules/bluetooth/spec/default/manifest.pp
+++ b/modules/bluetooth/spec/default/manifest.pp
@@ -1,0 +1,4 @@
+node default {
+
+  class { 'bluetooth': }
+}

--- a/modules/bluetooth/spec/default/spec.rb
+++ b/modules/bluetooth/spec/default/spec.rb
@@ -14,10 +14,6 @@ describe 'bluetooth' do
     it { should be_installed }
   end
 
-  describe package('bluez-cups') do
-    it { should be_installed }
-  end
-
   describe file('/etc/bluetooth/audio.conf') do
     its(:content) { should match /AutoConnect=true/ }
     its(:content) { should match /FastConnectable=true/ }

--- a/modules/bluetooth/spec/default/spec.rb
+++ b/modules/bluetooth/spec/default/spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'bluetooth' do
+
+  describe package('bluetooth') do
+    it { should be_installed }
+  end
+
+  describe package('bluez') do
+    it { should be_installed }
+  end
+
+  describe package('bluez-alsa') do
+    it { should be_installed }
+  end
+
+  describe package('bluez-cups') do
+    it { should be_installed }
+  end
+
+  describe file('/etc/bluetooth/audio.conf') do
+    its(:content) { should match /AutoConnect=true/ }
+    its(:content) { should match /FastConnectable=true/ }
+  end
+end

--- a/modules/bluetooth/templates/audio.conf
+++ b/modules/bluetooth/templates/audio.conf
@@ -1,0 +1,45 @@
+# Configuration file for the audio service
+
+# This section contains options which are not specific to any
+# particular interface
+[General]
+
+# Switch to master role for incoming connections (defaults to true)
+#Master=true
+
+# If we want to disable support for specific services
+# Defaults to supporting all implemented services
+#Disable=Gateway,Source,Socket
+
+# SCO routing. Either PCM or HCI (in which case audio is routed to/from ALSA)
+# Defaults to HCI
+#SCORouting=PCM
+
+# Automatically connect both A2DP and HFP/HSP profiles for incoming
+# connections. Some headsets that support both profiles will only connect the
+# other one automatically so the default setting of true is usually a good
+# idea.
+AutoConnect=<%= @audio_autoconnect %>
+
+# Headset interface specific options (i.e. options which affect how the audio
+# service interacts with remote headset devices)
+[Headset]
+
+# Set to true to support HFP, false means only HSP is supported
+# Defaults to true
+HFP=true
+
+# Maximum number of connected HSP/HFP devices per adapter. Defaults to 1
+MaxConnected=1
+
+# Set to true to enable use of fast connectable mode (faster page scanning)
+# for HFP when incoming call starts. Default settings are restored after
+# call is answered or rejected. Page scan interval is much shorter and page
+# scan type changed to interlaced. Such allows faster connection initiated
+# by a headset.
+FastConnectable=<%= @audio_fastconnectable %>
+
+# Just an example of potential config options for the other interfaces
+#[A2DP]
+#SBCSources=1
+#MPEG12Sources=0


### PR DESCRIPTION
See https://github.com/cargomedia/puppet-cargomedia/blob/master/docu/bulldog/setup.md#pair-bluetooth-headphones-bluebuds

See https://github.com/cargomedia/puppet-cargomedia/issues/1152

---
Steps for bluetooth/audio headset (audio-sink) support:
- [x] manage service
- [x] manage deps for `a2dp` support
- [x] audio config file for `auto-connect`
- [ ] support `auto-pairing`
- [ ] support `auto-trust`
- [ ] support `auto-profile` switch
