### PR TITLE
[Fluentd] - Gem dependency requires ruby 2.0

### DIFF
--- a/modules/fluentd/manifests/init.pp
+++ b/modules/fluentd/manifests/init.pp
@@ -1,7 +1,14 @@
 class fluentd {
 
+  # Version 0.14.0 breaks wheezy
+  # Dep strptime requires Ruby version ~> 2.0
+  $fluentd_version = $::facts['lsbdistcodename'] ? {
+    'wheezy' => '0.12.26',
+    default  => latest,
+  }
+
   ruby::gem { 'fluentd':
-    ensure => latest,
+    ensure => $fluentd_version,
   }
 
   file { '/etc/fluentd':


### PR DESCRIPTION
We're having errors on puppet runs, not sure on which nodes, wheezy only?

Looks like a `fluentd` dependency wants ruby 2.0

````

*** [XXX] Error: Could not update: Execution of '/usr/bin/gem install --no-rdoc --no-ri fluentd' returned 1: ERROR:  Error installing fluentd:
*** [XXX] strptime requires Ruby version ~> 2.0.
*** [XXX] Error: /Stage[main]/Fluentd/Ruby::Gem[fluentd]/Package[fluentd]/ensure: change from ["0.12.26", "0.12.25", "0.12.24", "0.12.23", "0.12.22"] to 0.14.0 failed: Could not update: Execution of '/usr/bin/gem install --no-rdoc --no-ri fluentd' returned 1: ERROR:  Error installing fluentd:
*** [XXX] strptime requires Ruby version ~> 2.0.
```

