### PR TITLE
fluentd 0.14.0 troubles

### DIFF
--- a/modules/fluentd/manifests/init.pp
+++ b/modules/fluentd/manifests/init.pp
@@ -1,11 +1,7 @@
 class fluentd {
 
-  # Version 0.14.0 breaks wheezy
-  # Dep strptime requires Ruby version ~> 2.0
-  $fluentd_version = $::facts['lsbdistcodename'] ? {
-    'wheezy' => '0.12.26',
-    default  => latest,
-  }
+  # Version 0.14.0 breaks
+  $fluentd_version = '0.12.26'
 
   ruby::gem { 'fluentd':
     ensure => $fluentd_version,


### PR DESCRIPTION
Not sure yet what is causing this..

* 0.12.26 runs flawlessly on bulldogs.
* Newest version (0.14.0) is active *only after a service restart* - it is very well possible that our Jessie nodes still run the old (0.12.26) one

Here the error dump on bulldog (service tries to start and gives up):
```
Jun 01 16:15:39 bulldog3 systemd[1]: Starting fluentd...
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: fluent/supervisor.rb:530:rescue in main_process: unexpected error error="no implicit conversion of nil into String"
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/serverengine-1.6.4/lib/serverengine/socket_manager_unix.rb:26:in `initialize'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/serverengine-1.6.4/lib/serverengine/socket_manager_unix.rb:26:in `new'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/serverengine-1.6.4/lib/serverengine/socket_manager_unix.rb:26:in `connect_peer'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/serverengine-1.6.4/lib/serverengine/socket_manager.rb:30:in `listen_tcp'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/plugin/in_forward.rb:100:in `listen'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/plugin/in_forward.rb:68:in `start'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/compat/call_super_mixin.rb:42:in `start'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/root_agent.rb:138:in `block in start'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/root_agent.rb:127:in `block (2 levels) in lifecycle'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/root_agent.rb:126:in `each'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/root_agent.rb:126:in `block in lifecycle'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/root_agent.rb:113:in `each'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/root_agent.rb:113:in `lifecycle'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/root_agent.rb:137:in `start'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/engine.rb:211:in `start'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/engine.rb:175:in `run'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/supervisor.rb:580:in `run_engine'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/supervisor.rb:382:in `block in run_worker'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/supervisor.rb:509:in `call'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/supervisor.rb:509:in `main_process'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/supervisor.rb:378:in `run_worker'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/lib/fluent/command/fluentd.rb:266:in `<top (required)>'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /var/lib/gems/2.1.0/gems/fluentd-0.14.0/bin/fluentd:5:in `<top (required)>'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /usr/local/bin/fluentd:23:in `load'
Jun 01 16:15:40 bulldog3 fluentd[31013]: 2016-06-01 16:15:40 +0000 [error]: command/fluentd.rb:266:<top (required)>: /usr/local/bin/fluentd:23:in `<main>'
```