### PR TITLE
Reduce janus log verbosity

### DIFF
--- a/modules/janus/manifests/server.pp
+++ b/modules/janus/manifests/server.pp
@@ -18,7 +18,7 @@ define janus::server (
   $core_dump = true,
   $ssl_cert = undef,
   $ssl_key = undef,
-  $debug_level = 3,
+  $log_level = 3,
 ) {
 
   require 'janus::common'

--- a/modules/janus/manifests/server.pp
+++ b/modules/janus/manifests/server.pp
@@ -18,6 +18,7 @@ define janus::server (
   $core_dump = true,
   $ssl_cert = undef,
   $ssl_key = undef,
+  $debug_level = 3,
 ) {
 
   require 'janus::common'

--- a/modules/janus/manifests/server.pp
+++ b/modules/janus/manifests/server.pp
@@ -18,6 +18,7 @@ define janus::server (
   $core_dump = true,
   $ssl_cert = undef,
   $ssl_key = undef,
+  $debug_level = 2,
 ) {
 
   require 'janus::common'

--- a/modules/janus/manifests/server.pp
+++ b/modules/janus/manifests/server.pp
@@ -18,7 +18,6 @@ define janus::server (
   $core_dump = true,
   $ssl_cert = undef,
   $ssl_key = undef,
-  $debug_level = 2,
 ) {
 
   require 'janus::common'

--- a/modules/janus/spec/cluster/manifest.pp
+++ b/modules/janus/spec/cluster/manifest.pp
@@ -6,7 +6,7 @@ node default {
 
   Janus::Server {
     prefix => $janus::cluster::prefix,
-    debug_level => 4,
+    log_level => 4,
   }
 
   Janus::Transport::Websockets {

--- a/modules/janus/spec/cluster/manifest.pp
+++ b/modules/janus/spec/cluster/manifest.pp
@@ -6,6 +6,7 @@ node default {
 
   Janus::Server {
     prefix => $janus::cluster::prefix,
+    debug_level => 4,
   }
 
   Janus::Transport::Websockets {

--- a/modules/janus/spec/role/standalone/manifest.pp
+++ b/modules/janus/spec/role/standalone/manifest.pp
@@ -1,7 +1,7 @@
 node default {
 
   Janus::Server {
-    debug_level => 4,
+    log_level => 4,
   }
 
   $instances = {

--- a/modules/janus/spec/role/standalone/manifest.pp
+++ b/modules/janus/spec/role/standalone/manifest.pp
@@ -1,5 +1,9 @@
 node default {
 
+  Janus::Server {
+    debug_level => 4,
+  }
+
   $instances = {
     'instance1' => {
       hostname                          => 'instance1.example.com',

--- a/modules/janus/templates/config
+++ b/modules/janus/templates/config
@@ -5,7 +5,7 @@ plugins_folder = <%= @plugins_folder %>
 transports_folder = <%= @transports_folder %>
 
 <% if @bind_address.nil? %>;<% end %>interface = <%= @bind_address %>	; Interface to use (will be used in SDP)
-debug_level = 4				; Debug/logging level, valid values are 0-7
+debug_level = <%= @debug_level %>				; Debug/logging level, valid values are 0-7
 debug_timestamps = yes		; Whether to show a timestamp for each log line
 debug_colors = no			; Whether colors should be disabled in the log
 

--- a/modules/janus/templates/config
+++ b/modules/janus/templates/config
@@ -5,7 +5,7 @@ plugins_folder = <%= @plugins_folder %>
 transports_folder = <%= @transports_folder %>
 
 <% if @bind_address.nil? %>;<% end %>interface = <%= @bind_address %>	; Interface to use (will be used in SDP)
-debug_level = <%= @debug_level %>				; Debug/logging level, valid values are 0-7
+debug_level = 3				; Debug/logging level, valid values are 0-7
 debug_timestamps = yes		; Whether to show a timestamp for each log line
 debug_colors = no			; Whether colors should be disabled in the log
 

--- a/modules/janus/templates/config
+++ b/modules/janus/templates/config
@@ -5,7 +5,7 @@ plugins_folder = <%= @plugins_folder %>
 transports_folder = <%= @transports_folder %>
 
 <% if @bind_address.nil? %>;<% end %>interface = <%= @bind_address %>	; Interface to use (will be used in SDP)
-debug_level = <%= @debug_level %>				; Debug/logging level, valid values are 0-7
+debug_level = <%= @log_level %>				; Debug/logging level, valid values are 0-7
 debug_timestamps = yes		; Whether to show a timestamp for each log line
 debug_colors = no			; Whether colors should be disabled in the log
 

--- a/modules/janus/templates/config
+++ b/modules/janus/templates/config
@@ -5,7 +5,7 @@ plugins_folder = <%= @plugins_folder %>
 transports_folder = <%= @transports_folder %>
 
 <% if @bind_address.nil? %>;<% end %>interface = <%= @bind_address %>	; Interface to use (will be used in SDP)
-debug_level = 3				; Debug/logging level, valid values are 0-7
+debug_level = <%= @debug_level %>				; Debug/logging level, valid values are 0-7
 debug_timestamps = yes		; Whether to show a timestamp for each log line
 debug_colors = no			; Whether colors should be disabled in the log
 


### PR DESCRIPTION
Currently the log is very verbose, which is not needed imo because we have most events already in cm-janus. 2 million events in the last 7 days.

@kris-lab Can we reduce the verbosity?