### PR TITLE
Modules using "ensure_packages" should require stdlibs

### DIFF
--- a/modules/dyndns/Puppetfile
+++ b/modules/dyndns/Puppetfile
@@ -1,3 +1,6 @@
+mod 'puppetlabs/stdlib',
+  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+
 mod 'cargomedia/apt',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/apt'

--- a/modules/unity/Puppetfile
+++ b/modules/unity/Puppetfile
@@ -1,3 +1,6 @@
+mod 'puppetlabs/stdlib',
+  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+
 mod 'cargomedia/apt',
    :git => 'git@github.com:cargomedia/puppet-packages.git',
    :path => 'modules/apt'


### PR DESCRIPTION
E.g. unity and dyndns
