### PR TITLE
Revert "Make sure daemon's monit entry for systemd does not output non-ASCII characters"

### DIFF
--- a/modules/daemon/templates/monit.systemd.erb
+++ b/modules/daemon/templates/monit.systemd.erb
@@ -1,2 +1,2 @@
-check program <%= @name %> path "/bin/systemctl status <%= @name %> 2>&1 >/dev/null"
+check program <%= @name %> path "/bin/systemctl status <%= @name %>"
 	if status != 0 then alert


### PR DESCRIPTION
Reverts cargomedia/puppet-packages#1358