### PR TITLE
socket-redis: lots of nginx connections

### DIFF
--- a/modules/cm/manifests/services/stream.pp
+++ b/modules/cm/manifests/services/stream.pp
@@ -34,6 +34,7 @@ class cm::services::stream(
     members             => $stream_members,
     upstream_cfg_append => [
       'ip_hash;',
+      'keepalive 4096;',
     ],
   }
 


### PR DESCRIPTION
socket-redis was not working anymore. Restarting helped.
Looking at some metrics it seems to me the reason could be saturation of network connections.

Active nginx connections over 1 month:
![screen shot 2016-06-17 at 20 07 58](https://cloud.githubusercontent.com/assets/360800/16160216/3b21d396-34c7-11e6-8f24-573e98ac1b82.png)

Network connections on the operating system level:
![screen shot 2016-06-17 at 20 09 22](https://cloud.githubusercontent.com/assets/360800/16160259/70a01e06-34c7-11e6-8c51-ba6c892d9df2.png)

While the actual subscriber count in socket-redis looks correct:
![screen shot 2016-06-17 at 20 09 57](https://cloud.githubusercontent.com/assets/360800/16160270/84ebdb7a-34c7-11e6-8812-23e5a5bd5347.png)

@kris-lab @ppp0 should we add some expiration for the connections in nginx?