### PR TITLE
Janus: network tuning

### DIFF
--- a/modules/janus/manifests/common.pp
+++ b/modules/janus/manifests/common.pp
@@ -11,6 +11,13 @@ class janus::common (
     system => true,
   }
 
+  sysctl::entry { 'janus':
+    entries => {
+      'net.core.rmem_default' => '33554432',
+      'net.core.rmem_max'     => '33554432',
+    }
+  }
+
   if $src_version {
     class { 'janus::source':
       version => $src_version,

--- a/modules/janus/manifests/server.pp
+++ b/modules/janus/manifests/server.pp
@@ -110,13 +110,6 @@ define janus::server (
     ],
   }
 
-  sysctl::entry { 'janus':
-    entries => {
-      'net.core.rmem_default' => '33554432',
-      'net.core.rmem_max'     => '33554432',
-    }
-  }
-
   if $instance_name != 'janus' {
     if ! defined(Service['janus']) {
       service { 'janus':

--- a/modules/janus/manifests/server.pp
+++ b/modules/janus/manifests/server.pp
@@ -112,8 +112,8 @@ define janus::server (
 
   sysctl::entry { 'janus':
     entries => {
-      'net.core.rmem_default' => "33554432",
-      'net.core.rmem_max' => "33554432",
+      'net.core.rmem_default' => '33554432',
+      'net.core.rmem_max'     => '33554432',
     }
   }
 

--- a/modules/janus/manifests/server.pp
+++ b/modules/janus/manifests/server.pp
@@ -110,6 +110,13 @@ define janus::server (
     ],
   }
 
+  sysctl::entry { 'janus':
+    entries => {
+      'net.core.rmem_default' => "33554432",
+      'net.core.rmem_max' => "33554432",
+    }
+  }
+
   if $instance_name != 'janus' {
     if ! defined(Service['janus']) {
       service { 'janus':


### PR DESCRIPTION
As investigated with Chris we should:

Increase the network receive buffer with sysctl:
- net.core.rmem_max = 32000000
- net.core.rmem_default = 32000000

This will help about "RcvbufErrors" and subsequently dropped frames. We can monitor that with netstat: https://github.com/cargomedia/bipbip/issues/154