### PR TITLE
Add new prefix /resources for cm cdn-origin vhost

### DIFF
--- a/modules/cm/manifests/vhost.pp
+++ b/modules/cm/manifests/vhost.pp
@@ -95,7 +95,7 @@ define cm::vhost(
   }
 
   nginx::resource::location{ "${name}-origin-upstream":
-    location            => '~* ^/(vendor-css|vendor-js|library-css|library-js|layout)/',
+    location            => '~* ^/(resources|vendor-css|vendor-js|library-css|library-js|layout)/',
     vhost               => $cdn_origin_vhost,
     ssl                 => true,
     ssl_only            => true,


### PR DESCRIPTION
@fauvel please review

The idea is to introduce a new prefix `/resources`, which would be the *only* prefix for all js/css/image resources mid-term.
We can already use it for the new response you introduced.