### PR TITLE
Update janus-gateway-audioroom template with new config

### DIFF
--- a/modules/janus/manifests/plugin/audioroom.pp
+++ b/modules/janus/manifests/plugin/audioroom.pp
@@ -5,6 +5,7 @@ define janus::plugin::audioroom(
   $job_pattern = 'job-#{md5}',
   $rest_url = 'http://127.0.0.1:8088/janus',
   $jobs_path = undef,
+  $mixer_prebuffering = 0,
 ) {
 
   require 'janus::common'

--- a/modules/janus/templates/plugin/audioroom.cfg
+++ b/modules/janus/templates/plugin/audioroom.cfg
@@ -24,3 +24,10 @@ archive_path=<%= @archive_path %>
 ; #{time}     is timestamp (guint64)
 ; #{type}     is type ("audio", "video" or "thumb" string)
 recording_pattern=<%= @recording_pattern %>
+
+; The mixer pre-buffering allows to define the time window of audio
+; RTP source to be queued before it is mixed with another RTP sources.
+; By default is set to 6 packets what gives 240ms of time tolerance for
+; incoming packets. If set to 0 then pre-buffering is disabled, as well as
+; dropping of outdated packets is disabled.
+mixer_prebuffering=<%= @mixer_prebuffering %>


### PR DESCRIPTION
Depends on https://github.com/cargomedia/janus-gateway-audioroom/pull/39

---

Added `mixer_prebuffering` which should be set to `0` by default by puppet