### PR TITLE
Chromium bleeding-edge

### DIFF
--- a/modules/chromium/Puppetfile
+++ b/modules/chromium/Puppetfile
@@ -2,6 +2,10 @@ mod 'cargomedia/apt',
    :git => 'git@github.com:cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
+mod 'cargomedia/helper',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/helper'
+
 mod 'cargomedia/lightdm',
    :git => 'git@github.com:cargomedia/puppet-packages.git',
    :path => 'modules/lightdm'

--- a/modules/chromium/manifests/init.pp
+++ b/modules/chromium/manifests/init.pp
@@ -1,9 +1,29 @@
-class chromium {
+class chromium($build = undef) {
 
   require 'apt'
 
-  package { 'chromium-browser':
-    ensure   => present,
-    provider => 'apt',
+  if $build != undef {
+
+    ensure_packages([
+      'libpangocairo-1.0',
+      'libnss3',
+      'libcups2',
+      'libgconf2-4',
+      'libatk1.0-0',
+      'libasound2',
+      'libgtk2.0-0',
+      'libxss1',
+      'libxtst6'
+    ], { provider => 'apt' })
+
+    helper::script { 'install chrome browser':
+        content => template("${module_name}/chromium-installer/install.sh.erb"),
+        unless  => 'ls /usr/bin/chrome',
+    }
+  } else {
+    package { 'chromium-browser':
+      ensure   => present,
+      provider => 'apt',
+    }
   }
 }

--- a/modules/chromium/spec/bleeding-edge/manifest.pp
+++ b/modules/chromium/spec/bleeding-edge/manifest.pp
@@ -1,0 +1,7 @@
+node default {
+
+  class { 'chromium':
+    build => '386257',
+  }
+
+}

--- a/modules/chromium/spec/bleeding-edge/spec.rb
+++ b/modules/chromium/spec/bleeding-edge/spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'chromium:bleeding-edge' do
+
+  describe command('chromium-browser --version') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match 'Chromium 51' }
+  end
+
+end

--- a/modules/chromium/templates/chromium-installer/install.sh.erb
+++ b/modules/chromium/templates/chromium-installer/install.sh.erb
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+curl -sL "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2f<%= @build %>%2fchrome-linux.zip?alt=media" > chrome-linux.zip
+rm -rf /usr/local/chrome-linux
+unzip -d /usr/local chrome-linux.zip
+chmod -R +r /usr/local/chrome-linux
+chmod +x  /usr/local/chrome-linux /usr/local/chrome-linux/chrome
+
+cat <<EOF >/usr/bin/chromium-browser
+#!/bin/bash -e
+/usr/local/chrome-linux/chrome --disable-setuid-sandbox \$@
+EOF
+
+chmod +x /usr/bin/chromium-browser


### PR DESCRIPTION
For https://github.com/cargomedia/janus-gateway-js/pull/67 it is necessary to have a newer version of chromium than the one that comes with the deb package