### PR TITLE
Change monit service check for systemd

### DIFF
--- a/modules/daemon/templates/monit.systemd.erb
+++ b/modules/daemon/templates/monit.systemd.erb
@@ -1,2 +1,2 @@
-check program <%= @name %> path "/bin/systemctl status <%= @name %>"
+check program <%= @name %> path "/bin/systemctl is-active <%= @name %>"
 	if status != 0 then alert


### PR DESCRIPTION
Right now we query `systemctl status` which, as reported in https://github.com/cargomedia/puppet-cargomedia/issues/1336, quite often produces false positives (i.e. exits with non-zero even though the observed service is fine)

Proposition: lets use `systemctl is-active`

Problem number two is that a regularly stopped service will appear as failed (same as-of-now) unless we do some additional parsing of `systemctl status` for `code=exited, status=0`

e.g.
```
systemctl status puppet
● puppet.service - puppet
   Loaded: loaded (/etc/systemd/system/puppet.service; enabled)
   Active: inactive (dead) since Tue 2016-08-02 12:21:54 UTC; 13s ago
  Process: 11158 ExecStart=/opt/puppetlabs/bin/puppet agent --no-daemonize (code=exited, status=0/SUCCESS)
 Main PID: 11158 (code=exited, status=0/SUCCESS)
```
