### PR TITLE
logrotate issues can't find process to kill

### DIFF
--- a/modules/mongodb/manifests/core/mongos.pp
+++ b/modules/mongodb/manifests/core/mongos.pp
@@ -75,6 +75,6 @@ define mongodb::core::mongos (
   logrotate::entry { $instance_name:
     path              => "/var/log/mongodb/${instance_name}.log",
     rotation_newfile  => 'create',
-    postrotate_script => "kill -USR1 $(cat /var/run/${instance_name}.pid)",
+    postrotate_script => "kill -USR1 $(cat /var/run/${instance_name}.pid) 2>&1 >/dev/null || true",
   }
 }


### PR DESCRIPTION

New Sysadmin mails on Jessie servers:
```
Cron <XXX> test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )
```

```
password
to root 
/etc/cron.daily/logrotate:
logrotate_script: 2: kill: No such process

error: error running non-shared postrotate script for /var/log/mongodb/mongos_router.log of '/var/log/mongodb/mongos_router.log '
run-parts: /etc/cron.daily/logrotate exited with return code 1
```

