### PR TITLE
Elasticsearch: does not stop if package already installed

### DIFF
--- a/modules/elasticsearch/manifests/package.pp
+++ b/modules/elasticsearch/manifests/package.pp
@@ -21,7 +21,7 @@ class elasticsearch::package (
 
   exec { 'true && /etc/init.d/elasticsearch stop':
     path         => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-    unless       => 'false',
+    unless       => false,
     require      => Package['elasticsearch'],
     subscribe    => [Apt::Source['elasticsearch'], Package['elasticsearch']],
     refreshonly  => true,

--- a/modules/elasticsearch/manifests/package.pp
+++ b/modules/elasticsearch/manifests/package.pp
@@ -23,7 +23,7 @@ class elasticsearch::package (
     path         => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     unless       => 'false',
     require      => Package['elasticsearch'],
-    subscribe    => Apt::Source['elasticsearch'],
+    subscribe    => [Apt::Source['elasticsearch'], Package['elasticsearch']],
     refreshonly  => true,
   }
 

--- a/modules/elasticsearch/manifests/package.pp
+++ b/modules/elasticsearch/manifests/package.pp
@@ -22,6 +22,7 @@ class elasticsearch::package (
   exec { 'true && /etc/init.d/elasticsearch stop':
     path         => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     unless       => 'false;',
+    provider     => shell,
     require      => Package['elasticsearch'],
     subscribe    => [Apt::Source['elasticsearch'], Package['elasticsearch']],
     refreshonly  => true,

--- a/modules/elasticsearch/manifests/package.pp
+++ b/modules/elasticsearch/manifests/package.pp
@@ -18,12 +18,13 @@ class elasticsearch::package (
     ensure   => present,
     provider => apt,
   }
-  ~>
 
   exec { 'true && /etc/init.d/elasticsearch stop':
-    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-    unless      => 'true && /etc/init.d/elasticsearch status',
-    refreshonly => true,
+    path         => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    unless       => 'false',
+    require      => Package['elasticsearch'],
+    subscribe    => Apt::Source['elasticsearch'],
+    refreshonly  => true,
   }
 
 }

--- a/modules/elasticsearch/manifests/package.pp
+++ b/modules/elasticsearch/manifests/package.pp
@@ -21,7 +21,7 @@ class elasticsearch::package (
 
   exec { 'true && /etc/init.d/elasticsearch stop':
     path         => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-    unless       => false,
+    unless       => 'false;',
     require      => Package['elasticsearch'],
     subscribe    => [Apt::Source['elasticsearch'], Package['elasticsearch']],
     refreshonly  => true,


### PR DESCRIPTION
Part of https://github.com/cargomedia/puppet-packages/pull/1435 and https://github.com/cargomedia/puppet-packages/pull/1415

For `cargomedia/debian-7-amd64-plain` the spec succeeds, however for `cargomedia/debian-7-amd64-cm` it doesn't! The difference is that `elasticsearch` package is already there so the `stop` command is not executed.