### PR TITLE
Needrestart: manage global configuration

### DIFF
--- a/modules/needrestart/manifests/init.pp
+++ b/modules/needrestart/manifests/init.pp
@@ -1,6 +1,6 @@
 class needrestart (
   $restart_helper_path = '/usr/local/bin/needrestart-service',
-  $auto_apt_invoke = false,
+  $apt_invoke = false,
 ){
 
   package { 'needrestart':
@@ -15,7 +15,7 @@ class needrestart (
     mode    => '0755',
   }
 
-  if $auto_apt_invoke == false {
+  if $apt_invoke == false {
     file { '/etc/apt/apt.conf.d/99needrestart':
       ensure  => absent,
       require => Package['needrestart']

--- a/modules/needrestart/manifests/init.pp
+++ b/modules/needrestart/manifests/init.pp
@@ -4,7 +4,7 @@ class needrestart (
 ){
 
   package { 'needrestart':
-    provider => apt
+    provider => apt,
   }
 
   file { $restart_helper_path:
@@ -18,7 +18,7 @@ class needrestart (
   if $apt_invoke == false {
     file { '/etc/apt/apt.conf.d/99needrestart':
       ensure  => absent,
-      require => Package['needrestart']
+      require => Package['needrestart'],
     }
   }
 }

--- a/modules/needrestart/manifests/init.pp
+++ b/modules/needrestart/manifests/init.pp
@@ -1,6 +1,5 @@
 class needrestart (
   $restart_helper_path = '/usr/local/bin/needrestart-service',
-  $apt_invoke = false,
 ){
 
   package { 'needrestart':
@@ -15,10 +14,9 @@ class needrestart (
     mode    => '0755',
   }
 
-  if $apt_invoke == false {
-    file { '/etc/apt/apt.conf.d/99needrestart':
-      ensure  => absent,
-      require => Package['needrestart'],
-    }
+  # This will disable all services restart after upgrade
+  file { '/etc/apt/apt.conf.d/99needrestart':
+    ensure  => absent,
+    require => Package['needrestart'],
   }
 }

--- a/modules/needrestart/manifests/init.pp
+++ b/modules/needrestart/manifests/init.pp
@@ -14,7 +14,7 @@ class needrestart (
     mode    => '0755',
   }
 
-  # This will disable all services restart after upgrade
+  # This will disable the services restart after apt-upgrade
   file { '/etc/apt/apt.conf.d/99needrestart':
     ensure  => absent,
     require => Package['needrestart'],

--- a/modules/needrestart/manifests/init.pp
+++ b/modules/needrestart/manifests/init.pp
@@ -1,5 +1,6 @@
 class needrestart (
-  $restart_helper_path = '/usr/local/bin/needrestart-service'
+  $restart_helper_path = '/usr/local/bin/needrestart-service',
+  $auto_apt_invoke = false,
 ){
 
   package { 'needrestart':
@@ -12,5 +13,12 @@ class needrestart (
     owner   => '0',
     group   => '0',
     mode    => '0755',
+  }
+
+  if $auto_apt_invoke == false {
+    file { '/etc/apt/apt.conf.d/99needrestart':
+      ensure  => absent,
+      require => Package['needrestart']
+    }
   }
 }

--- a/modules/needrestart/spec/service/spec.rb
+++ b/modules/needrestart/spec/service/spec.rb
@@ -10,4 +10,8 @@ describe 'needrestart::service' do
     its(:stdout) { should match /1/ }
   end
 
+  describe file('/etc/apt/apt.conf.d/99needrestart') do
+    it { should_not be_file }
+  end
+
 end


### PR DESCRIPTION
Part of #1399 

By default `needrestart` add hooks for `dpkg` and `rpm` at `/etc/needrestart/hook.d`. It also configures basic behaviour for detection and auto restart at `/etc/needrestart/needrestart.conf`.

It leads to auto-restart of service by running `apt-get upgrade`. 

I think we should:
- or disable auto-restart or even auto detection
- or remove our custom `/usr/local/bin/needrestart-service` and replace with more fancy `needrestart` hook/configuration scripting

cc @njam @ppp0 

btw: currently it works properly on production