### PR TITLE
Install "latest" socket-redis

### DIFF
--- a/modules/socket_redis/manifests/init.pp
+++ b/modules/socket_redis/manifests/init.pp
@@ -1,4 +1,5 @@
 class socket_redis (
+  $version = 'latest',
   $redisHost = 'localhost',
   $socketPorts = [8090],
   $logDir = '/var/log/socket-redis',
@@ -40,7 +41,7 @@ class socket_redis (
   }
 
   package { 'socket-redis':
-    ensure   => present,
+    ensure   => $version,
     provider => 'npm',
     notify   => Service['socket-redis'],
   }


### PR DESCRIPTION
This was changed from "latest" to "present" during the Jessie update (https://github.com/cargomedia/puppet-packages/pull/1259) for no apparent reason.

@vogdb @kris-lab please review
cc @ppp0