### PR TITLE
Add foreman-systemd module

### DIFF
--- a/modules/foreman_systemd/Puppetfile
+++ b/modules/foreman_systemd/Puppetfile
@@ -1,0 +1,3 @@
+mod 'cargomedia/foreman',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/foreman'

--- a/modules/foreman_systemd/manifests/init.pp
+++ b/modules/foreman_systemd/manifests/init.pp
@@ -1,0 +1,11 @@
+class foreman_systemd {
+  
+  require 'foreman'
+  
+  file {'/usr/local/bin/foreman-systemd':
+    owner => 'root',
+    group => 'root',
+    mode  => '0755',
+    content => template('foreman_systemd/binary.sh'),
+  }
+}

--- a/modules/foreman_systemd/metadata.json
+++ b/modules/foreman_systemd/metadata.json
@@ -1,0 +1,16 @@
+{
+  "name": "cargomedia-foreman_systemd",
+  "version": "0.0.1",
+  "author": "Cargo Media",
+  "license": "MIT",
+  "summary": "foreman-systemd",
+  "source": "https://github.com/cargomedia/puppet-packages",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": ["8"]
+    }
+  ],
+  "dependencies": [
+  ]
+}

--- a/modules/foreman_systemd/spec/init/manifest.pp
+++ b/modules/foreman_systemd/spec/init/manifest.pp
@@ -1,0 +1,5 @@
+node default {
+
+  class { 'foreman_systemd':
+  }
+}

--- a/modules/foreman_systemd/spec/init/spec.rb
+++ b/modules/foreman_systemd/spec/init/spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'foreman_systemd::init' do
+  describe command('foreman-systemd') do
+    its(:exit_status) { should eq 1 }
+    its(:stderr) { should match('Usage') }
+    its(:stderr) { should match('Missing <command> param') }
+  end
+
+  describe command('foreman') do
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/modules/foreman_systemd/templates/binary.sh
+++ b/modules/foreman_systemd/templates/binary.sh
@@ -7,16 +7,16 @@ echoerr () {
 
 usage() { 
   echoerr "Usage:"
-  echoerr "  foreman-systemd install [-u <user>] <app-name> <procfile-path>"
+  echoerr "  foreman-systemd install [-u <user>] [-f <formation>] <app-name> <procfile-root-dir>"
   echoerr "  foreman-systemd start <app-name>"
   echoerr "  foreman-systemd stop <app-name>"
-  echoerr "  foreman-systemd reload [-u <user>] <app-name> <procfile-path>"
+  echoerr "  foreman-systemd reload [-u <user>] [-f <formation>] <app-name> <procfile-root-dir>"
   exit 1; 
 }
 
 install () {
   uninstall "${2}"
-  foreman export systemd --user "${1}" --app "${2}" --procfile "${3}"
+  foreman export systemd --user "${1}" --formation "#{2}" --app "${3}" --root "${4}"
 }
 
 uninstall () {
@@ -53,11 +53,15 @@ esac
 
 case "${COMMAND}" in
   install|reload)
-    APP_USER=root
-    while getopts "u:" o; do
+    APP_USER="root"
+    FORMATION="all=1"
+    while getopts "u:f:" o; do
         case "${o}" in
             u)
-                APP_USER=${OPTARG}
+                APP_USER="${OPTARG}"
+                ;;
+            f)
+                FORMATION="${OPTARG}"
                 ;;
             *)
                 usage
@@ -84,11 +88,11 @@ esac
 case "${COMMAND}" in
   install|reload)
     if [ "$1" == "" ]; then
-      echoerr "Missing <profile-path> param"
+      echoerr "Missing <procfile-root-dir> param"
       echoerr
       usage
     fi
-    ROOT_DIR=$(dirname $1)
+    ROOT_DIR=$1
     shift
     ;;
 esac
@@ -96,7 +100,7 @@ esac
 
 case "${COMMAND}" in
   install)
-    install $APP_USER $APP_NAME $ROOT_DIR
+    install $APP_USER $FORMATION $APP_NAME $ROOT_DIR
     ;;
   start)
     start $APP_NAME
@@ -106,7 +110,7 @@ case "${COMMAND}" in
     ;;
   reload)
     stop $APP_NAME
-    install $APP_USER $APP_NAME $ROOT_DIR
+    install $APP_USER $FORMATION $APP_NAME $ROOT_DIR
     start $APP_NAME
     ;;
   *)

--- a/modules/foreman_systemd/templates/binary.sh
+++ b/modules/foreman_systemd/templates/binary.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -e
+
+echoerr () {
+  echo "${1}" 1>&2
+}
+
+usage() { 
+  echoerr "Usage:"
+  echoerr "  foreman-systemd install [-u <user>] <app-name> <procfile-path>"
+  echoerr "  foreman-systemd start <app-name>"
+  echoerr "  foreman-systemd stop <app-name>"
+  echoerr "  foreman-systemd reload [-u <user>] <app-name> <procfile-path>"
+  exit 1; 
+}
+
+install () {
+  uninstall "${2}"
+  foreman export systemd --user "${1}" --app "${2}" --procfile "${3}"
+}
+
+uninstall () {
+  rm -rf "/etc/systemd/systemd/${1}"
+}
+
+start () {
+  systemctl start "${1}.target"
+  systemctl enable "${1}.target"
+}
+
+stop () {
+  systemctl disable "${1}.target"
+  systemctl stop "${1}.target"
+}
+
+if [ "$1" == "" ]; then
+  echoerr "Missing <command> param"
+  echoerr
+  usage
+fi
+COMMAND=$1
+shift
+
+case "${COMMAND}" in
+  install|start|stop|reload)
+    ;;
+  *)
+    echoerr "Invalid command ${command}"
+    echoerr
+    usage
+    ;;
+esac
+
+case "${COMMAND}" in
+  install|reload)
+    APP_USER=root
+    while getopts "u:" o; do
+        case "${o}" in
+            u)
+                APP_USER=${OPTARG}
+                ;;
+            *)
+                usage
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
+esac
+
+
+case "${COMMAND}" in
+  install|start|stop|reload)
+    if [ "$1" == "" ]; then
+      echoerr "Missing <app-name> param"
+      echoerr
+      usage
+    fi
+    APP_NAME="app-${1}"
+    shift
+    ;;
+esac
+  
+
+case "${COMMAND}" in
+  install|reload)
+    if [ "$1" == "" ]; then
+      echoerr "Missing <profile-path> param"
+      echoerr
+      usage
+    fi
+    ROOT_DIR=$(dirname $1)
+    shift
+    ;;
+esac
+
+
+case "${COMMAND}" in
+  install)
+    install $APP_USER $APP_NAME $ROOT_DIR
+    ;;
+  start)
+    start $APP_NAME
+    ;;
+  stop)
+    stop $APP_NAME
+    ;;
+  reload)
+    stop $APP_NAME
+    install $APP_USER $APP_NAME $ROOT_DIR
+    start $APP_NAME
+    ;;
+  *)
+    echoerr "Invalid command ${COMMAND}"
+    usage
+    ;;
+esac
+
+


### PR DESCRIPTION
https://github.com/ddollar/foreman/
For Debian 8.

---
Plus a convenient wrapper `foreman-systemd` for systemd:

**install**:
```
foreman-systemd install --user <user> <app-name> <Procfile-path>
```
Which runs:
```sh
# Uninstall:
rm -rf /etc/systemd/system/app-<app-name>*

# Install:
foreman export --user <user> --app app-<app-name> --root <Procfile-dir> systemd /etc/systemd/system
```

**start**:
```
foreman-systemd start <app-name>
```
Which runs:
```sh
systemctl start app-<app-name>.target
systemctl enable app-<app-name>.target
```

**stop**:
```
foreman-systemd stop <app-name>
```
Which runs:
```sh
systemctl disable app-<app-name>.target
systemctl stop app-<app-name>.target
```


**reload**:
```
foreman-systemd reload --user <user> <app-name> <Procfile-path>
```
Which runs:
```sh
stop()
install()
start()
```