### PR TITLE
Debian-8: upgrade "awscli" module

### DIFF
--- a/modules/awscli/manifests/init.pp
+++ b/modules/awscli/manifests/init.pp
@@ -1,7 +1,7 @@
-class awscli ($version = '1.3.9') {
+class awscli {
 
   python::pip { 'awscli':
-    ensure => $version,
+    ensure => present,
   }
 
 }

--- a/modules/awscli/metadata.json
+++ b/modules/awscli/metadata.json
@@ -8,7 +8,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["7"]
+      "operatingsystemrelease": ["7", "8"]
     }
   ],
   "dependencies": [

--- a/modules/awscli/spec/default/spec.rb
+++ b/modules/awscli/spec/default/spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'awscli' do
 
-  describe command('pip freeze | grep -w -- \^awscli==1.3.9') do
+  describe command('pip freeze | grep -w -- \^awscli==.*') do
     its(:exit_status) { should eq 0 }
   end
 


### PR DESCRIPTION
The version constraint of `1.3.9` seems to be not needed, see initial development https://github.com/cargomedia/puppet-packages/pull/598