### PR TITLE
Debian-8: upgrade "capistrano" module

### DIFF
--- a/modules/capistrano/manifests/init.pp
+++ b/modules/capistrano/manifests/init.pp
@@ -1,6 +1,6 @@
 class capistrano {
 
-  $version = $::facts['lsbdistcodename'] == 'wheezy' ? { true => '3.4.1', default => present }
+  $version = ($::facts['lsbdistcodename'] == 'wheezy')? { true => '3.4.1', default => present }
 
   ruby::gem { 'net-ssh':
     ensure => '2.8.0',

--- a/modules/capistrano/manifests/init.pp
+++ b/modules/capistrano/manifests/init.pp
@@ -2,6 +2,8 @@ class capistrano {
 
   if $::facts['lsbdistcodename'] == 'wheezy' {
     $version = '3.4.1'
+  } else {
+    $version = present
   }
 
   ruby::gem { 'net-ssh':

--- a/modules/capistrano/manifests/init.pp
+++ b/modules/capistrano/manifests/init.pp
@@ -1,11 +1,13 @@
 class capistrano {
 
+  $version = ($::facts['lsbdistcodename'] == 'wheezy') ? { true => '3.4.1', default => present }
+
   ruby::gem { 'net-ssh':
     ensure => '2.8.0',
   }
   ->
 
   ruby::gem { 'capistrano':
-    ensure => present,
+    ensure => $version,
   }
 }

--- a/modules/capistrano/manifests/init.pp
+++ b/modules/capistrano/manifests/init.pp
@@ -1,6 +1,6 @@
 class capistrano {
 
-  $version = ($::facts['lsbdistcodename'] == 'wheezy') ? { true => '3.4.1', default => present }
+  $version = $::facts['lsbdistcodename'] == 'wheezy' ? { true => '3.4.1', default => present }
 
   ruby::gem { 'net-ssh':
     ensure => '2.8.0',

--- a/modules/capistrano/manifests/init.pp
+++ b/modules/capistrano/manifests/init.pp
@@ -1,6 +1,8 @@
 class capistrano {
 
-  $version = ($::facts['lsbdistcodename'] == 'wheezy')? { true => '3.4.1', default => present }
+  if $::facts['lsbdistcodename'] == 'wheezy' {
+    $version = '3.4.1'
+  }
 
   ruby::gem { 'net-ssh':
     ensure => '2.8.0',

--- a/modules/capistrano/metadata.json
+++ b/modules/capistrano/metadata.json
@@ -8,7 +8,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["7"]
+      "operatingsystemrelease": ["7", "8"]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Latest version of `capistrano` is not working with `ruby@1.9.3`. For the time being we can stick to the version [3.4.1](https://rubygems.org/gems/capistrano/versions/3.4.1) for `Wheezy`. 