### PR TITLE
Introduce network::snat

### DIFF
--- a/modules/network/manifests/interface.pp
+++ b/modules/network/manifests/interface.pp
@@ -13,6 +13,7 @@ define network::interface (
   $wpa_ssid     = undef,
   $wpa_psk      = undef,
   $applyconfig  = true,
+  $snat = false,
 ) {
 
   include 'augeas'
@@ -56,6 +57,15 @@ define network::interface (
       path        => ['/bin', '/sbin', '/usr/bin'],
       refreshonly => true,
       subscribe   => Augeas["main-${device}"],
+    }
+  }
+
+  if $snat {
+    $network_interface = regsubst($device, '^([a-z]+\d?)(:?.?)*$', '\1')
+
+    network::snat { "SNAT on ${network_interface}":
+      interface => $network_interface,
+      source_address => $ipaddr,
     }
   }
 

--- a/modules/network/manifests/snat.pp
+++ b/modules/network/manifests/snat.pp
@@ -1,6 +1,6 @@
 define network::snat(
   $interface = undef,
-  $source_address = undef,
+  $source_address,
 ) {
 
   $iface = $interface ? {

--- a/modules/network/manifests/snat.pp
+++ b/modules/network/manifests/snat.pp
@@ -1,7 +1,5 @@
 define network::snat(
   $interface = undef,
-  $from_ip = undef,
-  $to_ip = undef,
   $source_address = undef,
 ) {
 
@@ -10,19 +8,9 @@ define network::snat(
     default => "-o ${interface}",
   }
 
-  $src = $from_ip ? {
-    undef => '',
-    default => "-s ${from_ip}",
-  }
-
-  $dest = $to_ip ? {
-    undef => '',
-    default => "-s ${to_ip}",
-  }
-
   iptables::entry { 'Set up SNAT':
     table => 'nat',
     chain => 'POSTROUTING',
-    rule  => "${iface} ${src} ${dest} -j SNAT --to-source ${source_address}",
+    rule  => "${iface} -j SNAT --to-source ${source_address}",
   }
 }

--- a/modules/network/manifests/snat.pp
+++ b/modules/network/manifests/snat.pp
@@ -1,0 +1,28 @@
+define network::snat(
+  $interface = undef,
+  $from_ip = undef,
+  $to_ip = undef,
+  $source_address = undef,
+) {
+
+  $iface = $interface ? {
+    undef => '',
+    default => "-o ${interface}",
+  }
+
+  $src = $from_ip ? {
+    undef => '',
+    default => "-s ${from_ip}",
+  }
+
+  $dest = $to_ip ? {
+    undef => '',
+    default => "-s ${to_ip}",
+  }
+
+  iptables::entry { 'Set up SNAT':
+    table => 'nat',
+    chain => 'POSTROUTING',
+    rule  => "${iface} ${src} ${dest} -j SNAT --to-source ${source_address}",
+  }
+}

--- a/modules/network/spec/alias-ip-and-snat/hiera.json
+++ b/modules/network/spec/alias-ip-and-snat/hiera.json
@@ -23,6 +23,12 @@
       "method": "static",
       "ipaddr": "192.168.20.122",
       "netmask": "255.255.255.0"
+    },
+    "lo:0": {
+      "method": "manual",
+      "ipaddr": "192.168.20.122",
+      "netmask": "255.255.255.0",
+      "snat": true
     }
   }
 }

--- a/modules/network/spec/alias-ip-and-snat/hiera.json
+++ b/modules/network/spec/alias-ip-and-snat/hiera.json
@@ -1,0 +1,28 @@
+{
+  "network::interfaces": {
+    "eth0": {
+      "method": "dhcp"
+    },
+    "eth1": {
+      "method": "static",
+      "ipaddr": "10.10.20.122",
+      "netmask": "255.255.255.0",
+      "slaves": "eth2 eth3",
+      "mtu": 9000,
+      "bonding_opts": {
+        "mode": 4,
+        "miimon": 100,
+        "downdelay": 0,
+        "updelay": 0,
+        "lacp-rate": "fast",
+        "xmit_hash_policy": 1
+      },
+      "route_opts": "route add -net 10.10.130.0 netmask 255.255.255.0 gw 10.10.20.128"
+    },
+    "eth1:0": {
+      "method": "static",
+      "ipaddr": "192.168.20.122",
+      "netmask": "255.255.255.0"
+    }
+  }
+}

--- a/modules/network/spec/alias-ip-and-snat/manifest.pp
+++ b/modules/network/spec/alias-ip-and-snat/manifest.pp
@@ -3,7 +3,14 @@ node default {
   require 'network'
 
   network::snat { 'Modify source ip for outgoing traffic on all interfaces':
-    from_ip => '10.10.20.122',
+    interface => 'lo',
     source_address => '192.168.20.122',
+  }
+
+  exec { 'Start listening on 1337':
+    command     => 'nc -lvnp 1337 -s 10.10.20.122 2>/tmp/stderr_output &',
+    user        => 'root',
+    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    provider    => shell,
   }
 }

--- a/modules/network/spec/alias-ip-and-snat/manifest.pp
+++ b/modules/network/spec/alias-ip-and-snat/manifest.pp
@@ -2,11 +2,6 @@ node default {
 
   require 'network'
 
-  network::snat { 'Modify source ip for outgoing traffic on all interfaces':
-    interface => 'lo',
-    source_address => '192.168.20.122',
-  }
-
   exec { 'Start listening on 1337':
     command     => 'nc -lvnp 1337 2>/tmp/stderr_output &',
     user        => 'root',

--- a/modules/network/spec/alias-ip-and-snat/manifest.pp
+++ b/modules/network/spec/alias-ip-and-snat/manifest.pp
@@ -8,7 +8,7 @@ node default {
   }
 
   exec { 'Start listening on 1337':
-    command     => 'nc -lvnp 1337 -s 10.10.20.122 2>/tmp/stderr_output &',
+    command     => 'nc -lvnp 1337 2>/tmp/stderr_output &',
     user        => 'root',
     path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     provider    => shell,

--- a/modules/network/spec/alias-ip-and-snat/manifest.pp
+++ b/modules/network/spec/alias-ip-and-snat/manifest.pp
@@ -1,0 +1,9 @@
+node default {
+
+  require 'network'
+
+  network::snat { 'Modify source ip for outgoing traffic on all interfaces':
+    from_ip => '10.10.20.122',
+    source_address => '192.168.20.122',
+  }
+}

--- a/modules/network/spec/alias-ip-and-snat/spec.rb
+++ b/modules/network/spec/alias-ip-and-snat/spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe 'network::alias_ip_and_snat' do
 
-  describe command ('nc -lvnp 1337 -s 10.10.20.122 2>/tmp/stderr_output &')  do
-    its(:exit_status) { should eq 0}
-  end
-
   describe command('curl --proxy "" --max-time 1 http://10.10.20.122:1337')  do
     its(:exit_status) { should eq 28}
   end

--- a/modules/network/spec/alias-ip-and-snat/spec.rb
+++ b/modules/network/spec/alias-ip-and-snat/spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 describe 'network::alias_ip_and_snat' do
 
   describe command('curl --proxy "" --max-time 1 http://10.10.20.122:1337')  do
-    its(:exit_status) { should eq 28}
+    its(:exit_status) { should be_between(28,52)}
   end
 
   describe file('/tmp/stderr_output') do
-    its(:content) { should match /connect to+.+from+.+192\.168\.20\.122/}
+    its(:content) { should match /[C|c]onnect+.+from+.+192\.168\.20\.122/}
   end
 end

--- a/modules/network/spec/alias-ip-and-snat/spec.rb
+++ b/modules/network/spec/alias-ip-and-snat/spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'network::alias_ip_and_snat' do
+
+  describe command('nc -lvnp 1337 -s 10.10.20.122 2>/tmp/stderr_output &') do
+    its(:exit_status) { should eq 0}
+  end
+
+  describe command('curl --proxy '' --max-time 1 http://10.10.20.122:1337')  do
+    its(:exit_status) { should eq 28}
+  end
+
+  describe file('/tmp/stderr_output') do
+    its(:content) { should match /connect to+.+from+.+192\.168\.20\.122/}
+  end
+end

--- a/modules/network/spec/alias-ip-and-snat/spec.rb
+++ b/modules/network/spec/alias-ip-and-snat/spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'network::alias_ip_and_snat' do
 
-  describe command('nc -lvnp 1337 -s 10.10.20.122 2>/tmp/stderr_output &') do
+  describe command ('nc -lvnp 1337 -s 10.10.20.122 2>/tmp/stderr_output &')  do
     its(:exit_status) { should eq 0}
   end
 
-  describe command('curl --proxy '' --max-time 1 http://10.10.20.122:1337')  do
+  describe command('curl --proxy "" --max-time 1 http://10.10.20.122:1337')  do
     its(:exit_status) { should eq 28}
   end
 

--- a/modules/network/spec/default/hiera.json
+++ b/modules/network/spec/default/hiera.json
@@ -1,0 +1,34 @@
+{
+  "network::interfaces": {
+    "eth0": {
+      "method": "dhcp"
+    },
+    "eth1": {
+      "method": "static",
+      "ipaddr": "10.10.20.122",
+      "netmask": "255.255.255.0",
+      "slaves": "eth2 eth3",
+      "mtu": 9000,
+      "bonding_opts": {
+        "mode": 4,
+        "miimon": 100,
+        "downdelay": 0,
+        "updelay": 0,
+        "lacp-rate": "fast",
+        "xmit_hash_policy": 1
+      },
+      "route_opts": "route add -net 10.10.130.0 netmask 255.255.255.0 gw 10.10.20.128"
+    },
+    "eth3": {
+      "method": "manual",
+      "ipaddr": "10.10.40.10"
+    }
+  },
+
+  "network::hosts": {
+    "foo": {
+      "ipaddr": "10.10.10.100",
+      "aliases": ["boo", "moo"]
+    }
+  }
+}

--- a/modules/network/spec/default/manifest.pp
+++ b/modules/network/spec/default/manifest.pp
@@ -1,41 +1,6 @@
 node default {
 
-  network::interface { 'eth0':
-    method      => 'dhcp',
-  }
-  ->
-
-  network::interface { 'eth1':
-    method       => 'static',
-    ipaddr       => '10.10.20.122',
-    netmask      => '255.255.255.0',
-    slaves       => 'eth2 eth3',
-    mtu          => 9000,
-    bonding_opts => {
-      'mode' => 4,
-      'miimon' => 100,
-      'downdelay' => 0,
-      'updelay' => 0,
-      'lacp-rate' => 'fast',
-      'xmit_hash_policy' => 1
-    },
-    route_opts   => 'route add -net 10.10.130.0 netmask 255.255.255.0 gw 10.10.20.128',
-  }
-  ->
-
-  network::interface { 'eth3':
-    method      => 'manual',
-    ipaddr      => '10.10.40.10',
-    netmask     => '255.255.255.0',
-    gateway     => '10.10.40.1',
-    mtu         => 16000,
-  }
-  ->
-
-  network::host { 'foo':
-    ipaddr  => '10.10.10.100',
-    aliases => ['boo', 'moo']
-  }
+  require 'network'
 
   class { 'network::resolv':
     search     => ['example.local', 'example.com'],

--- a/modules/network/spec/default/spec.rb
+++ b/modules/network/spec/default/spec.rb
@@ -18,9 +18,6 @@ eth1_matches = [
 eth3_matches = [
   'iface eth3 inet manual',
   'address 10.10.40.10',
-  'netmask 255.255.255.0',
-  'gateway 10.10.40.1',
-  'mtu 16000',
 ]
 
 describe 'network' do


### PR DESCRIPTION
Needed to change the source ip address of outgoing packages (aka source NAT, snat) if we want to fully use Softlayer's Global public IP address as a sender, too