### PR TITLE
Introduce systemd::critical_units package

### DIFF
--- a/modules/systemd/manifests/critical_unit.pp
+++ b/modules/systemd/manifests/critical_unit.pp
@@ -1,12 +1,12 @@
 define systemd::critical_unit (
-  $serviceName
+  $unitName
 ){
 
   include 'systemd::daemon_reload'
 
-  file { "/etc/systemd/system/critical-units.target.wants/${serviceName}":
+  file { "/etc/systemd/system/critical-units.target.wants/${unitName}":
     ensure  => link,
-    target  => "/etc/systemd/system/${serviceName}",
+    target  => "/etc/systemd/system/${unitName}",
     owner   => '0',
     group   => '0',
     mode    => '0644',

--- a/modules/systemd/manifests/critical_unit.pp
+++ b/modules/systemd/manifests/critical_unit.pp
@@ -1,0 +1,16 @@
+define systemd::critical_unit (
+  $serviceName
+){
+
+  include 'systemd::daemon_reload'
+
+  file { "/etc/systemd/system/critical-units.target.wants/${serviceName}":
+    ensure  => link,
+    target  => "/etc/systemd/system/${serviceName}",
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+    notify  => Exec['systemctl daemon-reload'],
+  }
+
+}

--- a/modules/systemd/manifests/critical_units.pp
+++ b/modules/systemd/manifests/critical_units.pp
@@ -1,0 +1,23 @@
+class systemd::critical_units {
+  
+  file { '/etc/systemd/system/critical-units.target':
+    ensure  => file,
+    content => template("${module_name}/critical-units.target"),
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+    notify  => Exec['systemctl daemon-reload'],
+  }
+
+  file { '/etc/systemd/system/critical-units.target.wants/':
+    ensure  => directory,
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+    purge   => true,
+    recurse => true,
+  } 
+  
+  Systemd::Critical_unit <||>
+  
+}

--- a/modules/systemd/manifests/critical_units.pp
+++ b/modules/systemd/manifests/critical_units.pp
@@ -16,7 +16,7 @@ class systemd::critical_units {
     mode    => '0644',
     purge   => true,
     recurse => true,
-  } 
+  }
   
   Systemd::Critical_unit <||>
   

--- a/modules/systemd/manifests/init.pp
+++ b/modules/systemd/manifests/init.pp
@@ -2,12 +2,12 @@ class systemd {
 
   require 'apt'
   include 'systemd::coredump'
+  include 'systemd::critical_units'
 
   package { 'systemd':
     ensure   => present,
     provider => 'apt',
   }
 
-  class { 'systemd::critical_units':}
 
 }

--- a/modules/systemd/manifests/init.pp
+++ b/modules/systemd/manifests/init.pp
@@ -8,4 +8,6 @@ class systemd {
     provider => 'apt',
   }
 
+  class { 'systemd::critical_units':}
+
 }

--- a/modules/systemd/manifests/unit.pp
+++ b/modules/systemd/manifests/unit.pp
@@ -27,4 +27,10 @@ define systemd::unit(
     subscribe => File["/etc/systemd/system/${name}.service"],
     before    => Exec["systemctl start ${name}"],
   }
+  
+  $serviceName = "${name}.service"
+  
+  @systemd::critical_unit { $serviceName:
+    serviceName => $serviceName,
+  }
 }

--- a/modules/systemd/manifests/unit.pp
+++ b/modules/systemd/manifests/unit.pp
@@ -28,9 +28,9 @@ define systemd::unit(
     before    => Exec["systemctl start ${name}"],
   }
   
-  $serviceName = "${name}.service"
+  $unitName = "${name}.service"
   
-  @systemd::critical_unit { $serviceName:
-    serviceName => $serviceName,
+  @systemd::critical_unit { $unitName:
+    unitName => $unitName,
   }
 }

--- a/modules/systemd/spec/critical_units/manifest.pp
+++ b/modules/systemd/spec/critical_units/manifest.pp
@@ -1,0 +1,7 @@
+node default {
+
+  systemd::unit { 'my-daemon':
+    content  => template('systemd/spec/my-daemon.service'),
+  }
+
+}

--- a/modules/systemd/spec/critical_units/spec.rb
+++ b/modules/systemd/spec/critical_units/spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'systemd::critical_units' do
+
+  describe file('/etc/systemd/system/critical-units.target') do
+    it { should be_file }
+  end
+
+  describe file('/etc/systemd/system/critical-units.target.wants/my-daemon.service') do
+    it { should be_symlink }
+  end
+
+  describe command('systemctl list-dependencies --plain critical-units.target | grep my-daemon.service') do
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/modules/systemd/templates/critical-units.target
+++ b/modules/systemd/templates/critical-units.target
@@ -1,0 +1,4 @@
+[Unit]
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Puppet class for a "critical" target in "systemd"
- Puppet "systemd::unit" should export a virtual resource, which will add a "Wants=" entry to the critical target

