### PR TITLE
User creation in mysql module - Ordering

### DIFF
--- a/modules/mysql/manifests/server.pp
+++ b/modules/mysql/manifests/server.pp
@@ -18,6 +18,7 @@ class mysql::server ($root_password = '', $debian_sys_maint_password = '') {
     system => true,
     home   => '/var/lib/mysql',
     shell  => '/bin/false',
+    before => Package['mysql-server'],
   }
 
   file { '/etc/mysql':


### PR DESCRIPTION
On a fresh Jessie installation I got this:

```
Error: Could not set home on user[mysql]: Execution of '/usr/sbin/usermod -d /var/lib/mysql mysql' returned 8: usermod: user mysql is currently used by process 22226
Error: /Stage[main]/Mysql::Server/User[mysql]/home: change from /nonexistent to /var/lib/mysql failed: Could not set home on user[mysql]: Execution of '/usr/sbin/usermod -d /var/lib/mysql mysql' returned 8: usermod: user mysql is currently used by process 22226
```

