### PR TITLE
Disable "memcache.allow-failover"

### DIFF
--- a/modules/php5/templates/extension/memcache/conf.ini
+++ b/modules/php5/templates/extension/memcache/conf.ini
@@ -7,3 +7,4 @@ memcache.maxfiles=0
 memcache.archivememlim=0
 memcache.maxfilesize=0
 memcache.maxratio=0
+memcache.allow-failover=0


### PR DESCRIPTION
set `memcache.allow-failover=0`  in `modules/php5/templates/extension/memcache/conf.ini`

related to https://github.com/cargomedia/cm/pull/2300