### PR TITLE
libimagick versioning: add one more package

### DIFF
--- a/modules/php5/manifests/extension/imagick.pp
+++ b/modules/php5/manifests/extension/imagick.pp
@@ -25,7 +25,7 @@ class php5::extension::imagick (
   } else {
     $imagemagick_dir = '/etc/ImageMagick-6'
     # see bug report https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=836958
-    apt::preference { ['imagemagick-common', 'libmagickcore-6.q16-2', 'libmagickwand-6.q16-2']:
+    apt::preference { ['imagemagick-common', 'libmagickcore-6.q16-2', 'libmagickwand-6.q16-2', 'libmagickcore-6.q16-2-extra']:
       pin => 'version 8:6.8.9.9-5+deb8u2',
     }
     ->


### PR DESCRIPTION
Checking results:
```
+++-=================================-=====================-=====================-========================================================================
ii  libmagic1:amd64                   1:5.22+15-2+deb8u1    amd64                 File type determination library using "magic" numbers
un  libmagickcore-6.q16-1-extra       <none>                <none>                (no description available)
ii  libmagickcore-6.q16-2:amd64       8:6.8.9.9-5+deb8u2    amd64                 low-level image manipulation library -- quantum depth Q16
ii  libmagickcore-6.q16-2-extra:amd64 8:6.8.9.9-5+deb8u4    amd64                 low-level image manipulation library - extra codecs (Q16)
un  libmagickcore-extra               <none>                <none>                (no description available)
ii  libmagickwand-6.q16-2:amd64       8:6.8.9.9-5+deb8u2    amd64                 image manipulation library
```

Package ` libmagickcore-6.q16-2-extra` was installed in a divergent (newest) version. To be on the safe side, let's enforce this one as well
