### PR TITLE
systemd: Use configuration files instead of symlink for units dependencies

### DIFF
--- a/modules/systemd/manifests/critical_unit.pp
+++ b/modules/systemd/manifests/critical_unit.pp
@@ -2,11 +2,13 @@ define systemd::critical_unit {
 
   include 'systemd::daemon_reload'
   
-  $wants = $name
+  $unit_configuration = {
+    'wants' => $name,
+  }
 
-  file { "/etc/systemd/system/critical-units.target.d/wants-${wants}.conf":
+  file { "/etc/systemd/system/critical-units.target.d/wants-${unit_configuration['wants']}.conf":
     ensure  => file,
-    content => template('systemd/conf'),
+    content => template('systemd/unit.erb'),
     owner   => '0',
     group   => '0',
     mode    => '0644',

--- a/modules/systemd/manifests/critical_unit.pp
+++ b/modules/systemd/manifests/critical_unit.pp
@@ -1,14 +1,15 @@
 define systemd::critical_unit {
 
   include 'systemd::daemon_reload'
+  
+  $wants = $name
 
-  file { "/etc/systemd/system/critical-units.target.wants/${name}":
-    ensure  => link,
-    target  => "/etc/systemd/system/${name}",
+  file { "/etc/systemd/system/critical-units.target.d/wants-${wants}.conf":
+    ensure  => file,
+    content => template('systemd/conf'),
     owner   => '0',
     group   => '0',
     mode    => '0644',
     notify  => Exec['systemctl daemon-reload'],
   }
-
 }

--- a/modules/systemd/manifests/target.pp
+++ b/modules/systemd/manifests/target.pp
@@ -3,10 +3,13 @@ define systemd::target(
   $purge = false,
 ) {
   $unit_name = "${name}.target"
+  $unit_configuration = {
+    'wanted_by' => 'multi-user.target'
+  }
 
-  systemd::unit{ $unit_name:
+  systemd::unit { $unit_name:
     service_name => $unit_name,
-    content  => template("${module_name}/target"),
+    content  => template("${module_name}/unit.erb"),
     critical => $critical,
   }
 

--- a/modules/systemd/manifests/target.pp
+++ b/modules/systemd/manifests/target.pp
@@ -10,7 +10,7 @@ define systemd::target(
     critical => $critical,
   }
 
-  file { "/etc/systemd/system/${unit_name}.wants":
+  file { "/etc/systemd/system/${unit_name}.d":
     ensure  => directory,
     owner   => '0',
     group   => '0',

--- a/modules/systemd/spec/critical_units/manifest.pp
+++ b/modules/systemd/spec/critical_units/manifest.pp
@@ -1,6 +1,10 @@
 node default {
 
-  systemd::service { 'my-daemon':
+  systemd::service { 'foo':
+    content  => template('systemd/spec/my-daemon.service'),
+  }
+
+  systemd::service { 'bar':
     content  => template('systemd/spec/my-daemon.service'),
   }
 }

--- a/modules/systemd/spec/critical_units/spec.rb
+++ b/modules/systemd/spec/critical_units/spec.rb
@@ -6,15 +6,11 @@ describe 'systemd::critical_units' do
     it { should be_file }
   end
 
-  describe file('/etc/systemd/system/critical-units.target.wants/my-daemon.service') do
-    it { should be_symlink }
+  describe command('systemctl list-dependencies --plain critical-units.target | grep foo.service') do
+    its(:exit_status) { should eq 0 }
   end
 
-  describe file('/etc/systemd/system/critical-units.target.wants/critical-units.target') do
-    it { should_not exist}
-  end
-
-  describe command('systemctl list-dependencies --plain critical-units.target | grep my-daemon.service') do
+  describe command('systemctl list-dependencies --plain critical-units.target | grep bar.service') do
     its(:exit_status) { should eq 0 }
   end
 

--- a/modules/systemd/templates/conf
+++ b/modules/systemd/templates/conf
@@ -1,6 +1,0 @@
-[Unit]
-<% if @wants -%>
-Wants=<%= @wants %>
-<% end -%>
-
-[Install]

--- a/modules/systemd/templates/conf
+++ b/modules/systemd/templates/conf
@@ -1,0 +1,6 @@
+[Unit]
+<% if @wants -%>
+Wants=<%= @wants %>
+<% end -%>
+
+[Install]

--- a/modules/systemd/templates/target
+++ b/modules/systemd/templates/target
@@ -1,4 +1,0 @@
-[Unit]
-
-[Install]
-WantedBy=multi-user.target

--- a/modules/systemd/templates/unit.erb
+++ b/modules/systemd/templates/unit.erb
@@ -1,0 +1,9 @@
+[Unit]
+<% if @unit_configuration['wants']-%>
+Wants=<%= @unit_configuration['wants'] %>
+<% end -%>
+
+[Install]
+<% if @unit_configuration['wanted_by'] -%>
+WantedBy=<%= @unit_configuration['wanted_by'] %>
+<% end -%>


### PR DESCRIPTION
I've played a bit more with systemd and found that some of the links from wants/requires directories (those manually created) are removed in chains - systemd thinks they are not needed anymore.

I will rework module to work on `/etc/systemd/system/{$service}.d/foo.conf` files.