### PR TITLE
Implement foreman-systemd helper cli

### DIFF
--- a/modules/cm/Puppetfile
+++ b/modules/cm/Puppetfile
@@ -29,6 +29,10 @@ mod 'cargomedia/foreman',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/foreman'
 
+mod 'cargomedia/foreman_systemd',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/foreman_systemd'
+
 mod 'cargomedia/mysql',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/mysql'

--- a/modules/cm/manifests/application.pp
+++ b/modules/cm/manifests/application.pp
@@ -22,6 +22,7 @@ class cm::application (
   require 'browserify'
   require 'autoprefixer'
   require 'foreman::debian'
+  require 'foreman_systemd'
   require 'mysql::client'
 
   class { 'php5::extension::opcache':

--- a/modules/cm/spec/application/spec.rb
+++ b/modules/cm/spec/application/spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'cm::application' do
 
-  describe command('if (which systemctl > /dev/null); then test -h /etc/systemd/system/critical-units.target.wants/cm-applications.target; fi') do
+  describe command('if (which systemctl > /dev/null); then test -f /etc/systemd/system/critical-units.target.d/wants-cm-applications.target.conf; fi') do
     its(:exit_status) { should eq 0 }
   end
 end

--- a/modules/foreman_systemd/Puppetfile
+++ b/modules/foreman_systemd/Puppetfile
@@ -1,0 +1,3 @@
+mod 'cargomedia/foreman',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/foreman'

--- a/modules/foreman_systemd/manifests/init.pp
+++ b/modules/foreman_systemd/manifests/init.pp
@@ -1,0 +1,11 @@
+class foreman_systemd {
+  
+  require 'foreman'
+  
+  file {'/usr/local/bin/foreman-systemd':
+    owner => 'root',
+    group => 'root',
+    mode  => '0755',
+    content => template('foreman_systemd/binary.sh'),
+  }
+}

--- a/modules/foreman_systemd/metadata.json
+++ b/modules/foreman_systemd/metadata.json
@@ -1,0 +1,16 @@
+{
+  "name": "cargomedia-foreman_systemd",
+  "version": "0.0.1",
+  "author": "Cargo Media",
+  "license": "MIT",
+  "summary": "foreman-systemd",
+  "source": "https://github.com/cargomedia/puppet-packages",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": ["8"]
+    }
+  ],
+  "dependencies": [
+  ]
+}

--- a/modules/foreman_systemd/spec/init/manifest.pp
+++ b/modules/foreman_systemd/spec/init/manifest.pp
@@ -1,0 +1,5 @@
+node default {
+
+  class { 'foreman_systemd':
+  }
+}

--- a/modules/foreman_systemd/spec/init/spec.rb
+++ b/modules/foreman_systemd/spec/init/spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'foreman_systemd::init' do
+  describe command('foreman-systemd') do
+    its(:exit_status) { should eq 1 }
+    its(:stderr) { should match('Usage') }
+    its(:stderr) { should match('Missing <command> param') }
+  end
+
+  describe command('foreman') do
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/modules/foreman_systemd/templates/binary.sh
+++ b/modules/foreman_systemd/templates/binary.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -e
+
+echoerr () {
+  echo "${1}" 1>&2
+}
+
+usage() { 
+  echoerr "Usage:"
+  echoerr "  foreman-systemd install [-u <user>] [-f <formation>] [-l <location>] <app-name> <root-dir>"
+  echoerr "  foreman-systemd start <app-name>"
+  echoerr "  foreman-systemd stop <app-name>"
+  echoerr "  foreman-systemd reload [-u <user>] [-f <formation>] [-l <location>] <app-name> <root-dir>"
+  exit 1; 
+}
+
+install () {
+  USER="${1}"
+  FORMATION="${2}"
+  APP_NAME="${3}"
+  ROOT_DIR="${4}"
+  LOCATION="${5}"
+  
+  uninstall "${APP_NAME}" "${LOCATION}"
+  foreman export systemd --user "${USER}" --formation "${FORMATION}" --app "${APP_NAME}" --root "${ROOT_DIR}" "${LOCATION}"
+}
+
+uninstall () {
+  APP_NAME="${1}"
+  LOCATION="${2}"
+  
+  rm -rf "${LOCATION}/${APP_NAME}"
+}
+
+start () {
+  APP_NAME="${1}"
+  
+  systemctl start "${APP_NAME}.target"
+  systemctl enable "${APP_NAME}.target"
+}
+
+stop () {
+  APP_NAME="${1}"
+  
+  systemctl disable "${APP_NAME}.target"
+  systemctl stop "${APP_NAME}.target"
+}
+
+if [ "$1" == "" ]; then
+  echoerr "Missing <command> param"
+  echoerr
+  usage
+fi
+COMMAND=$1
+shift
+
+case "${COMMAND}" in
+  install|start|stop|reload)
+    ;;
+  *)
+    echoerr "Invalid command ${command}"
+    echoerr
+    usage
+    ;;
+esac
+
+case "${COMMAND}" in
+  install|reload)
+    APP_USER="root"
+    FORMATION="all=1"
+    LOCATION="/etc/systemd/system"
+    while getopts "u:f:l:" o; do
+        case "${o}" in
+            u)
+                APP_USER="${OPTARG}"
+                ;;
+            f)
+                FORMATION="${OPTARG}"
+                ;;
+            l)
+                LOCATION="${OPTARG}"
+                ;;
+            *)
+                usage
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
+esac
+
+
+case "${COMMAND}" in
+  install|start|stop|reload)
+    if [ "$1" == "" ]; then
+      echoerr "Missing <app-name> param"
+      echoerr
+      usage
+    fi
+    APP_NAME="app-${1}"
+    shift
+    ;;
+esac
+  
+
+case "${COMMAND}" in
+  install|reload)
+    if [ "$1" == "" ]; then
+      echoerr "Missing <root-dir> param"
+      echoerr
+      usage
+    fi
+    ROOT_DIR=$1
+    shift
+    ;;
+esac
+
+
+case "${COMMAND}" in
+  install)
+    install $APP_USER $FORMATION $APP_NAME $ROOT_DIR $LOCATION 
+    ;;
+  start)
+    start $APP_NAME
+    ;;
+  stop)
+    stop $APP_NAME
+    ;;
+  reload)
+    stop $APP_NAME
+    install $APP_USER $FORMATION $APP_NAME $ROOT_DIR $LOCATION
+    start $APP_NAME
+    ;;
+  *)
+    echoerr "Invalid command ${COMMAND}"
+    usage
+    ;;
+esac
+
+

--- a/modules/foreman_systemd/templates/binary.sh
+++ b/modules/foreman_systemd/templates/binary.sh
@@ -21,15 +21,8 @@ install () {
   ROOT_DIR="${4}"
   LOCATION="${5}"
   
-  uninstall "${APP_NAME}" "${LOCATION}"
   foreman export systemd --user "${USER}" --formation "${FORMATION}" --app "${APP_NAME}" --root "${ROOT_DIR}" "${LOCATION}"
-}
-
-uninstall () {
-  APP_NAME="${1}"
-  LOCATION="${2}"
-  
-  rm -rf "${LOCATION}/${APP_NAME}"
+  systemctl daemon-reload
 }
 
 start () {
@@ -41,9 +34,8 @@ start () {
 
 stop () {
   APP_NAME="${1}"
-  
   systemctl disable "${APP_NAME}.target"
-  systemctl stop "${APP_NAME}.target"
+  if (systemctl --quiet is-active "${APP_NAME}.target"); then systemctl stop "${APP_NAME}.target"; fi
 }
 
 if [ "$1" == "" ]; then
@@ -117,18 +109,18 @@ esac
 
 case "${COMMAND}" in
   install)
-    install $APP_USER $FORMATION $APP_NAME $ROOT_DIR $LOCATION 
+    install "${APP_USER}" "${FORMATION}" "${APP_NAME}" "${ROOT_DIR}" "${LOCATION}" 
     ;;
   start)
-    start $APP_NAME
+    start "${APP_NAME}"
     ;;
   stop)
-    stop $APP_NAME
+    stop "${APP_NAME}"
     ;;
   reload)
-    stop $APP_NAME
-    install $APP_USER $FORMATION $APP_NAME $ROOT_DIR $LOCATION
-    start $APP_NAME
+    stop ${APP_NAME}
+    install "${APP_USER}" "${FORMATION}" "${APP_NAME}" "${ROOT_DIR}" "${LOCATION}"
+    start "${APP_NAME}"
     ;;
   *)
     echoerr "Invalid command ${COMMAND}"


### PR DESCRIPTION
Current help output:
```
root@debian-8-amd64-plain:~# foreman-systemd
Missing <command> param

Usage:
  foreman-systemd install [-u <user>] [-f <formation>] [-l <location>] [-w <wanted-by>] <app-name> <root-dir>
  foreman-systemd start <app-name>
  foreman-systemd stop <app-name>
  foreman-systemd reload [-u <user>] [-f <formation>] [-l <location>] [-w <wanted-by>] <app-name> <root-dir>
```