### PR TITLE
cm::vhost: enable gzip for AJAX requests by default

### DIFF
--- a/modules/cm/manifests/vhost.pp
+++ b/modules/cm/manifests/vhost.pp
@@ -57,6 +57,11 @@ define cm::vhost(
     ssl_key             => $ssl_key,
     ssl_port            => $ssl_port,
     location_cfg_append => [
+      'gzip on;',
+      'gzip_proxied any;',
+      'gzip_http_version 1.0;',
+      'gzip_min_length 1000;',
+      'gzip_types application/json application/x-javascript text/css text/plain application/xml image/svg+xml;',
       'include fastcgi_params;',
       'set_real_ip_from 0.0.0.0/0;',
       "fastcgi_param SCRIPT_FILENAME ${path}/public/index.php;",

--- a/modules/cm/manifests/vhost.pp
+++ b/modules/cm/manifests/vhost.pp
@@ -57,11 +57,6 @@ define cm::vhost(
     ssl_key             => $ssl_key,
     ssl_port            => $ssl_port,
     location_cfg_append => [
-      'gzip on;',
-      'gzip_proxied any;',
-      'gzip_http_version 1.0;',
-      'gzip_min_length 1000;',
-      'gzip_types application/json application/x-javascript text/css text/plain application/xml image/svg+xml;',
       'include fastcgi_params;',
       'set_real_ip_from 0.0.0.0/0;',
       "fastcgi_param SCRIPT_FILENAME ${path}/public/index.php;",
@@ -105,11 +100,6 @@ define cm::vhost(
     ssl                 => true,
     ssl_only            => true,
     location_cfg_append => [
-      'gzip on;',
-      'gzip_proxied any;',
-      'gzip_http_version 1.0;',
-      'gzip_min_length 1000;',
-      'gzip_types application/x-javascript text/css text/plain application/xml image/svg+xml;',
       'include fastcgi_params;',
       'set_real_ip_from 0.0.0.0/0;',
       "fastcgi_param SCRIPT_FILENAME ${path}/public/index.php;",
@@ -127,12 +117,6 @@ define cm::vhost(
     www_root            => "${path}/public",
     location_cfg_append => [
       'expires 1y;',
-      'gzip on;',
-      'gzip_proxied any;',
-      'gzip_http_version 1.0;',
-      'gzip_min_length 1000;',
-      'gzip_types application/x-javascript text/css text/plain application/xml image/svg+xml;',
-
       'add_header	Access-Control-Allow-Origin	*;',
     ],
   }
@@ -145,11 +129,6 @@ define cm::vhost(
     www_root            => "${path}/public",
     location_cfg_append => [
       'expires 1y;',
-      'gzip on;',
-      'gzip_proxied any;',
-      'gzip_http_version 1.0;',
-      'gzip_min_length 1000;',
-      'gzip_types application/x-javascript text/css text/plain application/xml image/svg+xml;',
     ],
   }
 }

--- a/modules/nginx/templates/conf.d/nginx.conf.erb
+++ b/modules/nginx/templates/conf.d/nginx.conf.erb
@@ -16,7 +16,11 @@ http {
 
   sendfile                  <%= scope.lookupvar('nginx::params::nx_sendfile')%>;
   <% if scope.lookupvar('nginx::params::nx_gzip') == 'on'%>
-  gzip                      on;
+  gzip                        on;
+  gzip_proxied                any;
+  gzip_http_version           1.0;
+  gzip_min_length             1000;
+  gzip_types application/json application/x-javascript text/css text/plain application/xml image/svg+xml;
   <% end %>
   client_max_body_size      <%= @client_max_body_size %>;
   keepalive_timeout         <%= @keepalive_timeout %>;

--- a/modules/nginx/templates/conf.d/nginx.conf.erb
+++ b/modules/nginx/templates/conf.d/nginx.conf.erb
@@ -20,7 +20,7 @@ http {
   gzip_proxied                any;
   gzip_http_version           1.0;
   gzip_min_length             1000;
-  gzip_types application/json application/x-javascript text/css text/plain application/xml image/svg+xml;
+  gzip_types application/json application/javascript application/x-javascript text/html text/css text/plain application/xml image/svg+xml;
   <% end %>
   client_max_body_size      <%= @client_max_body_size %>;
   keepalive_timeout         <%= @keepalive_timeout %>;

--- a/modules/revive/manifests/init.pp
+++ b/modules/revive/manifests/init.pp
@@ -63,10 +63,6 @@ class revive (
     location_cfg_append => [
       'root /var/revive/www;',
       'index index.php;',
-      'gzip on;',
-      'gzip_proxied any;',
-      'gzip_http_version 1.0;',
-      'gzip_types application/x-javascript text/css text/plain application/xml image/svg+xml;',
     ],
   }
 

--- a/modules/satis/manifests/init.pp
+++ b/modules/satis/manifests/init.pp
@@ -58,10 +58,6 @@ class satis(
     ssl_key             => $ssl_key,
     location_cfg_append => [
       'root /var/lib/satis/public/;',
-      'gzip on;',
-      'gzip_proxied any;',
-      'gzip_http_version 1.0;',
-      'gzip_types application/json text/plain;',
     ],
   }
 }


### PR DESCRIPTION
Part of https://github.com/cargomedia/puppet-cargomedia/issues/1518