### PR TITLE
Service on template does not match variable

### DIFF
--- a/modules/raid/manifests/linux_md.pp
+++ b/modules/raid/manifests/linux_md.pp
@@ -3,9 +3,9 @@ class raid::linux_md {
   require 'apt'
 
   if ($::facts['lsbdistcodename'] == 'vivid') {
-    $mdamd_service_name = 'mdadm'
+    $mdadm_service_name = 'mdadm'
   } else {
-    $mdamd_service_name = 'mdadm-raid'
+    $mdadm_service_name = 'mdadm-raid'
   }
 
   file { '/etc/mdadm':
@@ -21,7 +21,7 @@ class raid::linux_md {
     group   => '0',
     owner   => '0',
     mode    => '0644',
-    notify  => Service[$mdamd_service_name],
+    notify  => Service[$mdadm_service_name],
     before  => Package['mdadm'],
   }
 
@@ -39,13 +39,13 @@ class raid::linux_md {
   }
   ->
 
-  service { $mdamd_service_name:
+  service { $mdadm_service_name:
     hasstatus => false,
     enable    => true,
   }
 
   @monit::entry { 'mdadm-status':
     content => template("${module_name}/linux_md/monit.${::facts['service_provider']}.erb"),
-    require => Service[$mdamd_service_name],
+    require => Service[$mdadm_service_name],
   }
 }

--- a/modules/raid/templates/linux_md/monit.systemd.erb
+++ b/modules/raid/templates/linux_md/monit.systemd.erb
@@ -1,2 +1,2 @@
-check program raid-md path "/bin/systemctl status <%= @mdamd_service_name %>"
+check program raid-md path "/bin/systemctl status <%= @mdadm_service_name %>"
   if status != 0 then alert

--- a/modules/raid/templates/linux_md/monit.systemd.erb
+++ b/modules/raid/templates/linux_md/monit.systemd.erb
@@ -1,2 +1,2 @@
-check program raid-md path "/bin/systemctl status <%= @mdadm_service_name %>"
+check program raid-md path "/bin/systemctl status <%= @mdamd_service_name %>"
   if status != 0 then alert


### PR DESCRIPTION
Variable from template:
- https://github.com/cargomedia/puppet-packages/blob/master/modules/raid/templates/linux_md/monit.systemd.erb#L1

doesn't match one from manifest: 
- https://github.com/cargomedia/puppet-packages/blob/master/modules/raid/manifests/linux_md.pp#L6