### PR TITLE
Monit/daemon cleanup

### DIFF
--- a/modules/daemon/manifests/init.pp
+++ b/modules/daemon/manifests/init.pp
@@ -53,7 +53,7 @@ define daemon (
       }
 
       @monit::entry { $name:
-        content => template("${module_name}/monit.${service_provider}.erb"),
+        content => template("${module_name}/monit.debian.erb"),
         require => Service[$name],
       }
     }

--- a/modules/daemon/templates/monit.systemd.erb
+++ b/modules/daemon/templates/monit.systemd.erb
@@ -1,2 +1,0 @@
-check program <%= @name %> path "/bin/systemctl is-active <%= @name %>"
-	if status != 0 then alert

--- a/modules/monit/manifests/init.pp
+++ b/modules/monit/manifests/init.pp
@@ -32,10 +32,12 @@ class monit ($emailTo = 'root@localhost', $emailFrom = undef, $allowedHosts = []
   ->
 
   file { '/etc/monit/conf.d':
-    ensure => directory,
-    group  => '0',
-    owner  => '0',
-    mode   => '0755',
+    ensure  => directory,
+    group   => '0',
+    owner   => '0',
+    mode    => '0755',
+    purge   => true,
+    recurse => true,
   }
   ->
 


### PR DESCRIPTION
Followup from https://github.com/cargomedia/puppet-packages/pull/1497

- Cleanup daemon monit entry template (`monit.systemd.erb` unused)
- Purge monit entry directory

cc @ppp0 