### PR TITLE
Make sure "[/etc/monit/conf.d/alert" not removed every run

### DIFF
--- a/modules/monit/manifests/init.pp
+++ b/modules/monit/manifests/init.pp
@@ -32,10 +32,10 @@ class monit ($emailTo = 'root@localhost', $emailFrom = undef, $allowedHosts = []
   ->
 
   file { '/etc/monit/conf.d':
-    ensure  => directory,
-    group   => '0',
-    owner   => '0',
-    mode    => '0755',
+    ensure => directory,
+    group  => '0',
+    owner  => '0',
+    mode   => '0755',
     purge   => true,
     recurse => true,
   }
@@ -61,6 +61,13 @@ class monit ($emailTo = 'root@localhost', $emailFrom = undef, $allowedHosts = []
       group   => '0',
       owner   => '0',
       mode    => '0755';
+
+    '/etc/monit/conf.d/alert':
+      ensure  => file,
+      content => template("${module_name}/templates/alert-default"),
+      group   => '0',
+      owner   => '0',
+      mode    => '0755';
   }
   ->
 
@@ -71,15 +78,7 @@ class monit ($emailTo = 'root@localhost', $emailFrom = undef, $allowedHosts = []
     owner   => '0',
     mode    => '0755',
   }
-
-  exec { '/etc/monit/conf.d/alert':
-    command     => 'ln -s /etc/monit/templates/alert-default /etc/monit/conf.d/alert',
-    user        => 'root',
-    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-    creates     => '/etc/monit/conf.d/alert',
-    subscribe   => File['/etc/monit/conf.d', '/etc/monit/templates/alert-default'],
-    refreshonly => true,
-  }
+  ->
 
   file { '/etc/monit/monitrc':
     ensure  => file,

--- a/modules/monit/manifests/init.pp
+++ b/modules/monit/manifests/init.pp
@@ -32,10 +32,10 @@ class monit ($emailTo = 'root@localhost', $emailFrom = undef, $allowedHosts = []
   ->
 
   file { '/etc/monit/conf.d':
-    ensure => directory,
-    group  => '0',
-    owner  => '0',
-    mode   => '0755',
+    ensure  => directory,
+    group   => '0',
+    owner   => '0',
+    mode    => '0755',
     purge   => true,
     recurse => true,
   }
@@ -71,15 +71,15 @@ class monit ($emailTo = 'root@localhost', $emailFrom = undef, $allowedHosts = []
     owner   => '0',
     mode    => '0755',
   }
-  ->
 
   exec { '/etc/monit/conf.d/alert':
-    command => 'ln -s /etc/monit/templates/alert-default /etc/monit/conf.d/alert',
-    user    => 'root',
-    path    => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-    creates => '/etc/monit/conf.d/alert',
+    command     => 'ln -s /etc/monit/templates/alert-default /etc/monit/conf.d/alert',
+    user        => 'root',
+    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    creates     => '/etc/monit/conf.d/alert',
+    subscribe   => File['/etc/monit/conf.d', '/etc/monit/templates/alert-default'],
+    refreshonly => true,
   }
-  ->
 
   file { '/etc/monit/monitrc':
     ensure  => file,

--- a/modules/monit/manifests/init.pp
+++ b/modules/monit/manifests/init.pp
@@ -72,6 +72,9 @@ class monit ($emailTo = 'root@localhost', $emailFrom = undef, $allowedHosts = []
   file { '/usr/local/bin/monit-alert':
     ensure  => file,
     content => template("${module_name}/bin/monit-alert.sh"),
+    group   => '0',
+    owner   => '0',
+    mode    => '0755',
   }
   ->
 

--- a/modules/monit/manifests/init.pp
+++ b/modules/monit/manifests/init.pp
@@ -32,10 +32,10 @@ class monit ($emailTo = 'root@localhost', $emailFrom = undef, $allowedHosts = []
   ->
 
   file { '/etc/monit/conf.d':
-    ensure => directory,
-    group  => '0',
-    owner  => '0',
-    mode   => '0755',
+    ensure  => directory,
+    group   => '0',
+    owner   => '0',
+    mode    => '0755',
     purge   => true,
     recurse => true,
   }
@@ -63,20 +63,15 @@ class monit ($emailTo = 'root@localhost', $emailFrom = undef, $allowedHosts = []
       mode    => '0755';
 
     '/etc/monit/conf.d/alert':
-      ensure  => file,
-      content => template("${module_name}/templates/alert-default"),
-      group   => '0',
-      owner   => '0',
-      mode    => '0755';
+      ensure   => link,
+      target   => '/etc/monit/templates/alert-default',
+      replace  => false,
   }
   ->
 
   file { '/usr/local/bin/monit-alert':
     ensure  => file,
     content => template("${module_name}/bin/monit-alert.sh"),
-    group   => '0',
-    owner   => '0',
-    mode    => '0755',
   }
   ->
 


### PR DESCRIPTION
```
Notice: /Stage[main]/Monit/File[/etc/monit/conf.d/alert]/ensure: removed
Notice: /Stage[main]/Monit/Exec[/etc/monit/conf.d/alert]/returns: executed successfully
```