### PR TITLE
Configurable verbosity of daemons

### DIFF
--- a/modules/daemon/templates/systemd.service.erb
+++ b/modules/daemon/templates/systemd.service.erb
@@ -52,8 +52,6 @@ RuntimeDirectoryMode=<%= @runtime_directory_mode %>
 <% @env.each do |name, value| -%>
 Environment="<%= name %>=<%= value %>"
 <% end -%>
-StandardOutput=null
-StandardError=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Systemd's default is to capture STDOUT/STDERR of services and journaling them. This seems to be muted/overridden in our current setup.

This would conflict with
* https://github.com/cargomedia/puppet-packages/issues/1430
* https://github.com/cargomedia/puppet-packages/issues/1377

and with the move away from log files in general 