### PR TITLE
Managing ucf.conf to force confold on package install/upgrade

### DIFF
--- a/modules/ucf/Puppetfile
+++ b/modules/ucf/Puppetfile
@@ -1,0 +1,3 @@
+mod 'cargomedia/apt',
+   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :path => 'modules/apt'

--- a/modules/ucf/manifests/init.pp
+++ b/modules/ucf/manifests/init.pp
@@ -11,6 +11,8 @@ class ucf {
     before  => Package['ucf'],
   }
 
-  package { 'ucf': }
-
+  package { 'ucf':
+    ensure   => present,
+    provider => 'apt',
+  }
 }

--- a/modules/ucf/manifests/init.pp
+++ b/modules/ucf/manifests/init.pp
@@ -1,0 +1,16 @@
+class ucf {
+
+  require 'apt'
+
+  file { '/etc/ucf.conf':
+    ensure  => file,
+    content => template("${module_name}/ucf.conf"),
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+    before  => Package['ucf'],
+  }
+
+  package { 'ucf': }
+
+}

--- a/modules/ucf/metadata.json
+++ b/modules/ucf/metadata.json
@@ -1,0 +1,22 @@
+{
+  "name": "cargomedia-ucf",
+  "version": "0.0.1",
+  "author": "Cargo Media",
+  "license": "MIT",
+  "summary": "ucf - Update Configuration File(s): preserve user changes to config files",
+  "source": "https://github.com/cargomedia/puppet-packages",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": ["8"]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "15.04"
+      ]
+    }
+  ],
+  "dependencies": [
+  ]
+}

--- a/modules/ucf/spec/default/manifest.pp
+++ b/modules/ucf/spec/default/manifest.pp
@@ -1,0 +1,4 @@
+node default {
+
+  require 'ucf'
+}

--- a/modules/ucf/spec/default/spec.rb
+++ b/modules/ucf/spec/default/spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'ucf::default' do
+
+  describe package('ucf') do
+    it { should be_installed }
+  end
+
+  describe file('/etc/ucf.conf') do
+    it { should be_file }
+    its(:content) { should match /conf_force_conffold=YES/ }
+  end
+end

--- a/modules/ucf/templates/ucf.conf
+++ b/modules/ucf/templates/ucf.conf
@@ -1,0 +1,40 @@
+#
+# This file is a bourne shell snippet, and is sourced by the
+# ucf script for configuration.
+#
+
+# Debugging information: The default value is 0 (no debugging
+# information is printed). To change the default behavior, uncomment
+# the following line and set the value to 1.
+#
+# DEBUG=0
+
+# Verbosity: The default value is 0 (quiet). To change the default
+# behavior, uncomment the following line and set the value to 1.
+#
+# VERBOSE=0
+
+
+# The src directory. This is the directory where the historical
+# md5sums for a file are looked for.  Specifically, the historical
+# md5sums are looked for in the subdirectory ${filename}.md5sum.d/
+#
+# conf_source_dir=/some/path/
+
+# Force the installed file to be retained. The default is have this
+# variable unset, which makes the script ask in case of doubt. To
+# change the default behavior, uncomment the following line and set
+# the value to YES
+#
+# conf_force_conffold=YES
+conf_force_conffold=YES
+
+# Force the installed file to be overridden. The default is have this
+# variable unset, which makes the script ask in case of doubt. To
+# change the default behavior, uncomment the following line and set
+# the value to YES
+#
+# conf_force_conffnew=YES
+
+# Please note that only one of conf_force_conffold and
+# conf_force_conffnew should be set.


### PR DESCRIPTION
We have a new kind of failure during unattended upgrade

```
root@xxx:/home/admin$ apt-get upgrade
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Calculating upgrade... Done
The following packages will be upgraded:
  php-pear php5-cli php5-common php5-curl php5-dev php5-fpm php5-gd php5-intl php5-mcrypt php5-mysql php5-readline
11 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```

<img width="1414" alt="screen shot 2016-10-10 at 12 34 54" src="https://cloud.githubusercontent.com/assets/1888714/19233769/eb1f4218-8ee7-11e6-9870-9787bbbf7dee.png">


Introducing `/etc/apt/apt.conf.d/33-force-conf` with
```
Dpkg::Options {
   "--force-confdef";
   "--force-confold";
};
```

~~should fix it~~ UPDATE: It does not