### PR TITLE
Socket-redis: service not restarting on config changes

### DIFF
--- a/modules/socket_redis/spec/config_update/1-install.pp
+++ b/modules/socket_redis/spec/config_update/1-install.pp
@@ -1,0 +1,6 @@
+node default {
+
+  class { 'socket_redis':
+    socketPorts => [8090,8091],
+  }
+}

--- a/modules/socket_redis/spec/config_update/2-update.pp
+++ b/modules/socket_redis/spec/config_update/2-update.pp
@@ -1,0 +1,7 @@
+node default {
+
+  class { 'socket_redis':
+    statusPort  => '7085',
+    socketPorts => [7090,7091],
+  }
+}

--- a/modules/socket_redis/spec/config_update/spec.rb
+++ b/modules/socket_redis/spec/config_update/spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'socket_redis' do
+
+  describe package('socket-redis') do
+    it { should be_installed.by('npm') }
+  end
+
+  describe service('socket-redis') do
+    it { should be_running }
+    it { should be_enabled }
+  end
+
+  describe port(7085) do
+    it { should be_listening }
+  end
+
+  describe port(7090) do
+    it { should be_listening }
+  end
+
+  describe port(7091) do
+    it { should be_listening }
+  end
+end

--- a/modules/systemd/manifests/unit.pp
+++ b/modules/systemd/manifests/unit.pp
@@ -15,11 +15,18 @@ define systemd::unit(
     mode    => '0644',
     notify  => Exec['systemctl daemon-reload'],
   }
-  ~>
 
   exec { "systemctl start ${name}":
-    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     unless      => "systemctl is-active ${name}",
+    subscribe   => [File["/etc/systemd/system/${name}"], Exec['systemctl daemon-reload']],
+    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    refreshonly => true,
+  }
+
+  exec { "systemctl reload-or-restart ${name}":
+    onlyif      => "systemctl is-active ${name}",
+    subscribe   => [File["/etc/systemd/system/${name}"], Exec['systemctl daemon-reload']],
+    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     refreshonly => true,
   }
 

--- a/modules/systemd/manifests/unit.pp
+++ b/modules/systemd/manifests/unit.pp
@@ -18,23 +18,17 @@ define systemd::unit(
 
   exec { "systemctl start ${name}":
     unless      => "systemctl is-active ${name}",
-    subscribe   => [File["/etc/systemd/system/${name}"], Exec['systemctl daemon-reload']],
-    path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-    refreshonly => true,
-  }
-
-  exec { "systemctl reload-or-restart ${name}":
-    onlyif      => "systemctl is-active ${name}",
-    subscribe   => [File["/etc/systemd/system/${name}"], Exec['systemctl daemon-reload']],
+    subscribe   => File["/etc/systemd/system/${name}"],
     path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
     refreshonly => true,
   }
 
   Service <| title == $service_name |> {
-    enable    => true,
-    provider  => 'systemd',
-    subscribe => File["/etc/systemd/system/${name}"],
-    before    => Exec["systemctl start ${name}"],
+    enable      => true,
+    provider    => 'systemd',
+    subscribe   => File["/etc/systemd/system/${name}"],
+    before      => Exec["systemctl start ${name}"],
+    require     => Exec['systemctl daemon-reload'],
   }
 
   if ($critical) {


### PR DESCRIPTION
Reproduce:

Run socket-redis spec once:
```sh
bundle exec rake spec:socket_redis os=Debian-8
```

Change spec from:
```puppet
  class { 'socket_redis':
    socketPorts => [8090,8091],
  }
```
to:
```puppet
  class { 'socket_redis':
    socketPorts => [8090,8091],
    redisHost => 'foo',
  }
```

Apply the spec again:
```sh
bundle exec rake spec:socket_redis os=Debian-8 keep_box=true
```

Output:
```
Notice: Compiled catalog for debian-8-amd64-plain.vagrantup.com in environment production in 1.16 seconds
Notice: /Stage[main]/Socket_redis/Daemon[socket-redis]/Systemd::Service[socket-redis]/Systemd::Unit[socket-redis.service]/File[/etc/systemd/system/socket-redis.service]/content: content changed '{md5}718268e5b200903a0f8660c6054086bd' to '{md5}01120f84da485c8a0c021e64ac86ab65'
Notice: /Stage[main]/Socket_redis/Daemon[socket-redis]/Service[socket-redis]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Socket_redis/Daemon[socket-redis]/Systemd::Service[socket-redis]/Systemd::Unit[socket-redis.service]/Exec[systemctl start socket-redis.service]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Systemd::Daemon_reload/Exec[systemctl daemon-reload]: Triggered 'refresh' from 1 events
```

Process list still has:
```
# ps aux | grep socket
socket-+  9876  0.1  0.9 1076100 37620 ?       Ssl  16:57   0:00 /usr/bin/node /usr/bin/socket-redis --log-dir=/var/log/socket-redis --status-port=8085 --redis-host=localhost --socket-ports=8090,8091
```

cc @ppp0 @kris-lab 

Could be even a daemon/systemd issue?