### PR TITLE
Use /tmp as home directory for composer

### DIFF
--- a/modules/composer/manifests/init.pp
+++ b/modules/composer/manifests/init.pp
@@ -10,7 +10,7 @@ class composer($version = '1.2.1') {
     path    => ['/usr/local/bin', '/usr/bin', '/bin'],
     unless  => "${binary} --version | grep -qw 'Composer version ${version}'",
     require => [File[$binary]],
-    environment => ['HOME=sweet_home'],
+    environment => ['HOME=/tmp'],
   }
 
   file { $binary:


### PR DESCRIPTION
In the class `composer` we're using `sweet_home` as the `HOME` environment variable.
This will be *created* by composer:
```sh
root@sk:/home/vagrant# ls -a sweet_home/
.  ..  .composer
```

Instead use `/tmp`?