### PR TITLE
Retry specs in PR mode?

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,4 @@ Our test tasks recognize following rake options:
 - `keep_box=true` do not roll back the vm to a clean state
 - `gui=true` show virtualbox GUI
 - `os='Debian-7,Ubuntu-15.04'` limit running specs to listed OS versions
-- `retries=NUM` how many times to re-run a failed spec (default: 2)
-- `no_retries=true|false` re-run failed specs or not (overrides `retries=NUM`)
+- `retries=NUM` how many times to re-run a failed spec (default: 0)

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ Our test tasks recognize following rake options:
 - `keep_box=true` do not roll back the vm to a clean state
 - `gui=true` show virtualbox GUI
 - `os='Debian-7,Ubuntu-15.04'` limit running specs to listed OS versions
+- `retries=NUM` how many times to re-run a failed spec (default: 2)
+- `no_retries=true|false` re-run failed specs or not (overrides `retries=NUM`)

--- a/build-ci.sh
+++ b/build-ci.sh
@@ -15,5 +15,5 @@ if [ -z "${ghprbTargetBranch}" ]; then
 else
     # Pull request build
     git fetch origin
-    bundle exec rake spec:changes_from_branch[origin/${ghprbTargetBranch}]
+    no_retries=true bundle exec rake spec:changes_from_branch[origin/${ghprbTargetBranch}]
 fi

--- a/build-ci.sh
+++ b/build-ci.sh
@@ -11,9 +11,9 @@ bundle exec rake lint
 vagrant box update
 if [ -z "${ghprbTargetBranch}" ]; then
     # Full project build
-    bundle exec rake spec
+    retries=2 bundle exec rake spec
 else
     # Pull request build
     git fetch origin
-    no_retries=true bundle exec rake spec:changes_from_branch[origin/${ghprbTargetBranch}]
+    bundle exec rake spec:changes_from_branch[origin/${ghprbTargetBranch}]
 fi

--- a/spec/lib/spec_runner.rb
+++ b/spec/lib/spec_runner.rb
@@ -169,13 +169,12 @@ module PuppetModules
 
     include EventEmitter
 
-    attr_accessor :filter_os_list, :retries_on_failure, :no_retry
+    attr_accessor :filter_os_list, :retries_on_failure
 
     def initialize
       @specs = []
       @filter_os_list = nil
-      @retries_on_failure = ENV.has_key?('retries') ? ENV['retries'].to_i : 2
-      @no_retry = (ENV['no_retry'] != 'false' if ENV.has_key?('no_retry')) | false
+      @retries_on_failure = ENV.has_key?('retries') ? ENV['retries'].to_i : 0
     end
 
     # @param [Spec[]]
@@ -192,9 +191,9 @@ module PuppetModules
           next unless @filter_os_list.nil? or @filter_os_list.include? os
           emit(:output, "Running #{spec.name} for #{os}\n".bold)
           example_result = {}
-          @retries_on_failure.times do
+          (@retries_on_failure+1).times do
               example_result = run_spec_in_box(spec, os)
-              break if example_result.success? or @no_retry === true
+              break if example_result.success?
               emit(:output, "Re-Running #{spec.name} for #{os}\n".bold)
           end
           emit(:output, example_result.summary)

--- a/spec/lib/spec_runner.rb
+++ b/spec/lib/spec_runner.rb
@@ -169,11 +169,13 @@ module PuppetModules
 
     include EventEmitter
 
-    attr_accessor :filter_os_list
+    attr_accessor :filter_os_list, :retries_on_failure, :no_retry
 
     def initialize
       @specs = []
       @filter_os_list = nil
+      @retries_on_failure = ENV.has_key?('retries') ? ENV['retries'].to_i : 2
+      @no_retry = (ENV['no_retry'] != 'false' if ENV.has_key?('no_retry')) | false
     end
 
     # @param [Spec[]]
@@ -189,7 +191,12 @@ module PuppetModules
         spec.puppet_module.supported_os_list.each do |os|
           next unless @filter_os_list.nil? or @filter_os_list.include? os
           emit(:output, "Running #{spec.name} for #{os}\n".bold)
-          example_result = run_spec_in_box(spec, os)
+          example_result = {}
+          @retries_on_failure.times do
+              example_result = run_spec_in_box(spec, os)
+              break if example_result.success? or @no_retry === true
+              emit(:output, "Re-Running #{spec.name} for #{os}\n".bold)
+          end
           emit(:output, example_result.summary)
           result.spec_result_list.push(example_result)
         end


### PR DESCRIPTION
Because of network failures etc single specs can fail.
How about we retry specs X times during pull-request mode?
