### PR TITLE
Vagrant plugin specs failing

### DIFF
--- a/modules/vagrant/Puppetfile
+++ b/modules/vagrant/Puppetfile
@@ -5,3 +5,7 @@ mod 'cargomedia/helper',
 mod 'cargomedia/apt',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/apt'
+
+mod 'cargomedia/build',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/build'

--- a/modules/vagrant/manifests/plugin.pp
+++ b/modules/vagrant/manifests/plugin.pp
@@ -4,7 +4,7 @@ define vagrant::plugin(
   $version = undef
 ) {
 
-  require 'vagrant'
+  require ['vagrant', 'build::gpp']
 
   if ($version) {
     $listOutput = "${name} (${version})"

--- a/modules/vagrant/spec/plugin-versioned/manifest.pp
+++ b/modules/vagrant/spec/plugin-versioned/manifest.pp
@@ -1,9 +1,9 @@
 node default {
 
-  vagrant::plugin { 'vagrant-phpstorm-tunnel':
+  vagrant::plugin { 'vagrant-proxyconf':
     user      => 'root',
     user_home => '/root',
-    version   => '0.1.0',
+    version   => '1.5.1',
   }
 
 }

--- a/modules/vagrant/spec/plugin-versioned/spec.rb
+++ b/modules/vagrant/spec/plugin-versioned/spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe 'vagrant::plugin versioned' do
 
   describe command('vagrant plugin list') do
-    its(:stdout) { should match 'vagrant-phpstorm-tunnel \(0.1.0\)' }
+    its(:stdout) { should match 'vagrant-proxyconf \(1.5.1\)' }
   end
 end

--- a/modules/vagrant/spec/plugin/manifest.pp
+++ b/modules/vagrant/spec/plugin/manifest.pp
@@ -1,6 +1,6 @@
 node default {
 
-  vagrant::plugin { 'vagrant-phpstorm-tunnel':
+  vagrant::plugin { 'vagrant-proxyconf':
     user      => 'root',
     user_home => '/root',
   }

--- a/modules/vagrant/spec/plugin/spec.rb
+++ b/modules/vagrant/spec/plugin/spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe 'vagrant::plugin' do
 
   describe command('vagrant plugin list') do
-    its(:stdout) { should match 'vagrant-phpstorm-tunnel' }
+    its(:stdout) { should match 'vagrant-proxyconf' }
   end
 end


### PR DESCRIPTION
Full repo build was almost successful except for those specs:

```
Finished in 14 hrs 8 mins 17 secs.
Failure! 389 specs run, 3 failures (1600 examples, 3 failures)
Failed examples:

    vagrant::plugin Command "vagrant plugin list" stdout 
    vagrant Package "vagrant" 
    vagrant::plugin versioned Command "vagrant plugin list" stdout 
```

not related to networking (btw, squid cache was still in place but all requests were MISS, so basically no caching at all)