### PR TITLE
Move ssl nginx config to main config, enable http2

### DIFF
--- a/modules/nginx/metadata.json
+++ b/modules/nginx/metadata.json
@@ -9,10 +9,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": ["8"]
-    },
-    {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [ "15.04" ]
     }
   ],
   "dependencies": [

--- a/modules/nginx/spec/proxy/spec.rb
+++ b/modules/nginx/spec/proxy/spec.rb
@@ -20,7 +20,6 @@ describe 'nginx proxy' do
     it { should be_file }
     its(:content) { should match /listen(.*)8090/ }
     its(:content) { should match /proxy_pass(.*)backend-socketredis/ }
-    its(:content) { should match /ssl(.*)on/ }
     its(:content) { should match /proxy_buffering(.*)off/ }
   end
 

--- a/modules/nginx/templates/conf.d/nginx.conf.erb
+++ b/modules/nginx/templates/conf.d/nginx.conf.erb
@@ -36,5 +36,9 @@ http {
   server_names_hash_bucket_size <%= @server_names_hash_bucket_size %>;
   <% end -%>
 
+  ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
+  ssl_session_timeout         10m;
+  ssl_session_cache           shared:SSL:20m;
+
   include /etc/nginx/conf.d/*.conf;
 }

--- a/modules/nginx/templates/vhost/vhost_ssl_header.erb
+++ b/modules/nginx/templates/vhost/vhost_ssl_header.erb
@@ -1,15 +1,11 @@
 server {
-  listen       <%= @listen_ip %>:<%= @ssl_port %>;
+  listen       <%= @listen_ip %>:<%= @ssl_port %> ssl http2;
 <% unless @server_name.empty? %>
   server_name           <%= @server_name.join(" ") %>;
 <% end %>
 
-  ssl on;
   ssl_certificate      <%= @ssl_cert_file %>;
   ssl_certificate_key  <%= @ssl_key_file %>;
-  ssl_session_timeout  10m;
-  ssl_session_cache    shared:SSL:20m;
-  ssl_prefer_server_ciphers   on;
 
 <% if @vhost_cfg_prepend -%><% @vhost_cfg_prepend.each do |option| -%>
   <%= option %>


### PR DESCRIPTION
Addressing https://github.com/cargomedia/puppet-cargomedia/issues/860

HTTP/2 will not work in Chrome because we have OpenSSL 1.0.1 but need 1.0.2, see
https://www.nginx.com/blog/supporting-http2-google-chrome-users/