### PR TITLE
Remove socket-redis UFW application

### DIFF
--- a/modules/socket_redis/manifests/init.pp
+++ b/modules/socket_redis/manifests/init.pp
@@ -46,10 +46,6 @@ class socket_redis (
     notify   => Service['socket-redis'],
   }
 
-  @ufw::application { 'socket-redis':
-    app_ports => inline_template("${statusPort},<%= @socketPorts.join(',')%>/tcp"),
-  }
-
   @bipbip::entry { 'socket-redis':
     plugin  => 'socket-redis',
     options => {


### PR DESCRIPTION
Added #1606 

Not needed after all - by default socket-redis is used as upstream for nginx.