### PR TITLE
[UFW] Re-configure socket-redis rules

### DIFF
--- a/modules/cm/manifests/services/stream.pp
+++ b/modules/cm/manifests/services/stream.pp
@@ -44,6 +44,6 @@ class cm::services::stream(
   }
 
   @ufw::application { 'cm-services-stream':
-    app_ports => inline_template("${port},<%= @socket_ports.join(',')%>,${status_port}/tcp"),
+    app_ports => inline_template("${port},${status_port}/tcp"),
   }
 }


### PR DESCRIPTION
Part of https://github.com/cargomedia/puppet-packages/pull/1608

> copying @njam 
The reason is that we have UFW on all machines now?
services/stream.pp: is socket_ports needed? Isn't this just internal for nginx?
services/stream.pp: not sure if status_port should be open. In our case it should be open only on the "private" network.
Maybe open a new ticket to discuss?