### PR TITLE
Control php5-fpm service with "daemon"

### DIFF
--- a/modules/php5/manifests/fpm.pp
+++ b/modules/php5/manifests/fpm.pp
@@ -64,13 +64,16 @@ class php5::fpm {
     provider => 'apt',
   }
 
-  service { 'php5-fpm':
-    enable    => true,
-    require   => Package['php5-fpm'],
+  daemon { 'php5-fpm':
+    binary      => '/usr/sbin/php5-fpm',
+    args        => '--nodaemonize --fpm-config /etc/php5/fpm/php-fpm.conf',
+    pre_command => '/usr/lib/php5/php5-fpm-checkconf',
+    require     => [
+      File['/etc/php5/fpm/php.ini'],
+      Package['php5-fpm'],
+    ],
     subscribe => Class['php5::config_extension_change'],
   }
-
-  @systemd::critical_unit { 'php5-fpm.service': }
 
   @bipbip::entry { 'php5-fpm':
     plugin  => 'fastcgi-php-fpm',


### PR DESCRIPTION
Unit from package:
```
[Unit]
Description=The PHP FastCGI Process Manager
After=network.target

[Service] 
Type=notify
PIDFile=/var/run/php5-fpm.pid
ExecStartPre=/usr/lib/php5/php5-fpm-checkconf
ExecStart=/usr/sbin/php5-fpm --nodaemonize --fpm-config /etc/php5/fpm/php-fpm.conf
ExecReload=/bin/kill -USR2 $MAINPID

[Install]
WantedBy=multi-user.target
```

Daemon unit:
```
[Unit]
Description=php5-fpm
After=network.target

[Service]
Type=simple
ExecStartPre=/usr/lib/php5/php5-fpm-checkconf
ExecStart=/usr/sbin/php5-fpm --nodaemonize --fpm-config /etc/php5/fpm/php-fpm.conf
User=root
PermissionsStartOnly=true
TimeoutStopSec=20
KillMode=mixed
Restart=always
StandardOutput=null
StandardError=null

[Install]
WantedBy=multi-user.target
```