### PR TITLE
Fix mongo/replica custom provider JSON parsing

### DIFF
--- a/modules/mongodb/lib/puppet/provider/mongodb.rb
+++ b/modules/mongodb/lib/puppet/provider/mongodb.rb
@@ -33,6 +33,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     output.gsub!(/ISODate\((.+?)\)/, '\1 ')
     output.gsub!(/Timestamp\((.+?)\)/, '[\1]')
     output.gsub!(/ObjectId\((.+?)\)/, '1')
+    output.gsub!(/NumberLong\((.+?)\)/, '\1 ')
 
     JSON.parse(output)
   end


### PR DESCRIPTION
e.g.
```json
{
	"set" : "rep1",
	"date" : "2017-01-27T17:27:57.821Z" ,
	"myState" : 1,
	"term" : NumberLong(-1),
	"heartbeatIntervalMillis" : NumberLong(2000),
	"members" : []
}
```