### PR TITLE
Pass hub-url config down to jetbrains::app resource

### DIFF
--- a/modules/jetbrains/manifests/application.pp
+++ b/modules/jetbrains/manifests/application.pp
@@ -7,6 +7,7 @@ define jetbrains::application (
   $port,
   $download_url,
   $config,
+  $hub_url = undef,
 ) {
 
   require 'nginx'

--- a/modules/jetbrains/manifests/upsource.pp
+++ b/modules/jetbrains/manifests/upsource.pp
@@ -17,6 +17,7 @@ class jetbrains::upsource (
     port         => $port,
     download_url => "https://download.jetbrains.com/upsource/upsource-${version}.${build}.zip",
     config       => file("${module_name}/upsource.config"),
+    hub_url      => $hub_url,
   }
 
 }

--- a/modules/jetbrains/manifests/youtrack.pp
+++ b/modules/jetbrains/manifests/youtrack.pp
@@ -17,5 +17,6 @@ class jetbrains::youtrack (
     port         => $port,
     download_url => "https://download.jetbrains.com/charisma/youtrack-${version}.${build}.zip",
     config       => file("${module_name}/youtrack.config"),
+    hub_url      => $hub_url,
   }
 }

--- a/modules/jetbrains/spec/upsource/spec.rb
+++ b/modules/jetbrains/spec/upsource/spec.rb
@@ -19,4 +19,9 @@ describe 'jetbrains-upsource' do
     it { should be_listening }
   end
 
+  describe file('/usr/local/jetbrains-upsource/conf/internal/bundle.properties') do
+    its(:content) { should_not match /hub-url=/ }
+    its(:content) { should match /^disable.hub=false$/ }
+  end
+
 end

--- a/modules/jetbrains/spec/youtrack/manifest.pp
+++ b/modules/jetbrains/spec/youtrack/manifest.pp
@@ -55,6 +55,7 @@ eX+RzJyQxtZbvtQiHGFqYuHLmtPWteyadxj+y6w6hpbcQzbWkskAtFwSHILI0hx3
 0GMie3CQ2ud3klexfzuRdKuWxq/14bjfjY5pbmnOdDEZbQH0zo9z
 -----END RSA PRIVATE KEY-----
 ',
+    hub_url => 'https://localhost:8081/hub',
   }
   ->
 

--- a/modules/jetbrains/spec/youtrack/spec.rb
+++ b/modules/jetbrains/spec/youtrack/spec.rb
@@ -19,4 +19,9 @@ describe 'jetbrains-youtrack' do
     it { should be_listening }
   end
 
+  describe file('/usr/local/jetbrains-youtrack/conf/internal/bundle.properties') do
+    its(:content) { should match /^hub-url=https:\/\/localhost:8081\/hub$/ }
+    its(:content) { should match /^disable.hub=true$/ }
+  end
+
 end


### PR DESCRIPTION
Cont. #1663
Part of cargomedia/puppet-cargomedia#1784