### PR TITLE
Allow to specify stream server names in cm:services

### DIFF
--- a/modules/cm/manifests/services.pp
+++ b/modules/cm/manifests/services.pp
@@ -1,7 +1,14 @@
 class cm::services(
   $ssl_cert,
   $ssl_key,
+  $stream_options = { },
 ) {
+
+  $stream_options_defaults = {
+    server_name => [],
+    port        => 8090,
+  }
+  $stream_opts = merge($stream_options_defaults, $stream_options)
 
   include 'redis'
   include 'mysql::server'
@@ -11,7 +18,9 @@ class cm::services(
   include 'mongodb::role::standalone'
 
   class { 'cm::services::stream':
-    ssl_cert => $ssl_cert,
-    ssl_key  => $ssl_key,
+    server_name => $stream_opts[server_name],
+    port        => $stream_opts[port],
+    ssl_cert    => $ssl_cert,
+    ssl_key     => $ssl_key,
   }
 }

--- a/modules/cm/manifests/services/stream.pp
+++ b/modules/cm/manifests/services/stream.pp
@@ -1,4 +1,5 @@
 class cm::services::stream(
+  $server_name = [],
   $port = 8090,
   $ssl_cert,
   $ssl_key,
@@ -10,6 +11,7 @@ class cm::services::stream(
   include 'nginx'
 
   nginx::resource::vhost { 'stream-server':
+    server_name         => $server_name,
     listen_port         => $port,
     ssl                 => true,
     ssl_port            => $port,

--- a/modules/cm/spec/services/stream-with-server_name/manifest.pp
+++ b/modules/cm/spec/services/stream-with-server_name/manifest.pp
@@ -1,0 +1,15 @@
+node default {
+
+  class { 'cm::services::stream':
+    server_name => ['example.dev'],
+    port       => 443,
+    ssl_cert   => template('cm/spec/spec-ssl.pem'),
+    ssl_key    => template('cm/spec/spec-ssl.key'),
+  }
+
+  host { 'mock-domain-resolution':
+    host_aliases => ['example.dev'],
+    ip           => '127.0.0.1',
+  }
+
+}

--- a/modules/cm/spec/services/stream-with-server_name/spec.rb
+++ b/modules/cm/spec/services/stream-with-server_name/spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'cm::services::stream' do
+
+  describe command("curl --proxy '' --insecure 'https://example.dev/'") do
+    its(:stdout) { should match 'Welcome to SockJS!' }
+  end
+
+end


### PR DESCRIPTION
Helpful to use WebSocket on the default HTTPS port with a specific domain