### PR TITLE
BO-83 Mysql systemd unit errors when starting

### DIFF
--- a/modules/mysql/manifests/server.pp
+++ b/modules/mysql/manifests/server.pp
@@ -132,8 +132,6 @@ class mysql::server (
     user                   => 'mysql',
     stop_timeout           => 600,
     limit_nofile           => 16384,
-    runtime_directory      => 'mysqld',
-    runtime_directory_mode => '0755',
     require                => [ User['mysql'], File['/usr/share/mysql/mysql-systemd-start'] ],
   }
 

--- a/modules/mysql/templates/mysql-systemd-start.sh.erb
+++ b/modules/mysql/templates/mysql-systemd-start.sh.erb
@@ -2,48 +2,62 @@
 #
 # Scripts to run by MySQL systemd service
 #
+# This file's original is from Debian Sid mysql-server-5.7 package
+#    http://http.debian.net/debian/pool/main/m/mysql-5.7/mysql-5.7_5.7.17-1.debian.tar.xz
+#    (see https://packages.debian.org/sid/mysql-server-5.7 for newest version)
+#
+#
 # Needed argument: pre | post
 #
 # pre mode  :  try to perform sanity check for configuration, log, data
 # post mode :  ping server until answer is received
-#
-# The source of the file can be found:
-# source-location: https://launchpadlibrarian.net/265197909/mysql-5.7_5.7.13.orig.tar.gz
-# file-location: ./packaging/deb-jessie/extra/mysql-systemd-start
 
+# Read a config option from mysql. Note that this will only work if a config
+# file actually specifies the option, so it's important to specify a default
+# $1 is application (e.g. mysqld for server)
+# $2 is option
+# $3 is default value used if no config value is found
+get_mysql_option() {
+        result=$(my_print_defaults "$1" | sed -n "s/^--$2=//p" | tail -n 1)
+        if [ -z "$result" ];
+        then
+                result="$3"
+        fi
+        echo "$result"
+}
 sanity () {
-if [ ! -r /etc/mysql/my.cnf ]; then
-echo "MySQL configuration not found at /etc/mysql/my.cnf. Please create one."
-exit 1
-fi
+  if [ ! -r /etc/mysql/my.cnf ]; then
+    echo "MySQL configuration not found at /etc/mysql/my.cnf. Please create one."
+    exit 1
+  fi
+  datadir=$(get_mysql_option mysqld datadir "/var/lib/mysql")
+  if [ ! -d "${datadir}" ] && [ ! -L "${datadir}" ]; then
+    echo "MySQL data dir not found at ${datadir}. Please create one."
+    exit 1
+  fi
 
-if [ ! -d /var/lib/mysql ] && [ ! -L /var/lib/mysql ]; then
-echo "MySQL data dir not found at /var/lib/mysql. Please create one."
-exit 1
-fi
-
-if [ ! -d /var/lib/mysql/mysql ] && [ ! -L /var/lib/mysql/mysql ]; then
-echo "MySQL system database not found. Please run mysql_install_db tool."
-exit 1
-fi
+  if [ ! -d "${datadir}/mysql" ] && [ ! -L "${datadir}/mysql" ]; then
+    echo "MySQL system database not found in ${datadir}. Please run mysqld --initialize."
+    exit 1
+  fi
 }
 
 pinger () {
-server_up=false
-for i in $(seq 1 30); do
-sleep 1
-if mysqladmin ping >/dev/null 2>&1; then
-server_up=true
-break
-fi
-done
-if [ ! $server_up ]; then
-echo "MySQL server not started"
-exit 1
-fi
+  server_up=false
+  for i in $(seq 1 30); do
+    sleep 1
+    if mysqladmin ping >/dev/null 2>&1; then
+      server_up=true
+      break
+    fi
+  done
+  if [ ! $server_up ]; then
+    echo "MySQL server not started"
+    exit 1
+  fi
 }
 
 case $1 in
-"pre")  sanity ;;
-"post") pinger ;;
+  "pre")  sanity ;;
+  "post") pinger ;;
 esac


### PR DESCRIPTION
Starting the mysql unit:
```
systemctl start mysql.service
```

Results in strange errors in the systemd log:
```
Jan 24 09:49:00 www2 systemd[1]: Starting mysql...
Jan 24 09:49:00 www2 systemd[2085]: Failed at step RUNTIME_DIRECTORY spawning /usr/share/mysql/mysql-systemd-start: File exists
Jan 24 09:49:00 www2 systemd[1]: mysql.service: control process exited, code=exited status=233
Jan 24 09:49:00 www2 systemd[1]: Failed to start mysql.
Jan 24 09:49:00 www2 systemd[1]: Unit mysql.service entered failed state.
Jan 24 09:49:00 www2 systemd[1]: mysql.service holdoff time over, scheduling restart.
Jan 24 09:49:00 www2 systemd[1]: Stopping mysql...
Jan 24 09:49:00 www2 systemd[1]: Starting mysql...
Jan 24 09:49:02 www2 systemd[1]: Started mysql.
```

This leads to problems when upgrading the package - dpkg errors.

Unit:
```
# /etc/systemd/system/mysql.service
[Unit]
Description=mysql
After=network.target

[Service]
Type=simple
ExecStartPre=/usr/share/mysql/mysql-systemd-start pre
ExecStart=/usr/sbin/mysqld 
ExecStartPost=/usr/share/mysql/mysql-systemd-start post
User=mysql
PermissionsStartOnly=true
TimeoutStopSec=600
KillMode=mixed
Restart=always
LimitNOFILE=16384
RuntimeDirectory=mysqld
RuntimeDirectoryMode=0755
StandardOutput=null
StandardError=null

[Install]
WantedBy=multi-user.target
```