### PR TITLE
[bug/feature] Puppet run state directory not world-readable anymore

### DIFF
--- a/modules/puppet/manifests/common.pp
+++ b/modules/puppet/manifests/common.pp
@@ -1,6 +1,6 @@
-class puppet::common(
+class puppet::common (
   $basemodulepath = '/etc/puppetlabs/code/modules',
-  $gems = [
+  $gems           = [
     'deep_merge',
     'ipaddress',
   ],
@@ -40,31 +40,26 @@ class puppet::common(
       ensure  => 'link',
       target  => '/opt/puppetlabs/bin/hiera',
       require => Package['puppet-agent'];
-  }
-
-  file { ['/etc/puppetlabs', '/etc/puppetlabs/puppet', '/etc/puppetlabs/code']:
-    ensure => directory,
-    group  => '0',
-    owner  => '0',
-    mode   => '0644',
-  }
-
-  file { '/etc/puppetlabs/puppet/conf.d':
-    ensure  => directory,
-    group   => '0',
-    owner   => '0',
-    mode    => '0644',
-    purge   => true,
-    recurse => true,
-  }
-
-  file { '/etc/puppetlabs/puppet/conf.d/main':
-    ensure  => file,
-    content => template("${module_name}/config"),
-    group   => '0',
-    owner   => '0',
-    mode    => '0644',
-    notify  => Exec['/etc/puppetlabs/puppet/puppet.conf'],
+    ['/etc/puppetlabs', '/etc/puppetlabs/puppet', '/etc/puppetlabs/code',
+      '/opt/puppetlabs/puppet/cache']:
+      ensure => directory,
+      group  => '0',
+      owner  => '0',
+      mode   => '0644';
+    '/etc/puppetlabs/puppet/conf.d':
+      ensure  => directory,
+      group   => '0',
+      owner   => '0',
+      mode    => '0644',
+      purge   => true,
+      recurse => true;
+    '/etc/puppetlabs/puppet/conf.d/main':
+      ensure  => file,
+      content => template("${module_name}/config"),
+      group   => '0',
+      owner   => '0',
+      mode    => '0644',
+      notify  => Exec['/etc/puppetlabs/puppet/puppet.conf'],
   }
 
   exec { '/etc/puppetlabs/puppet/puppet.conf':


### PR DESCRIPTION
Lots of bipbip errors:

````
E, [2017-02-20T11:48:42.232706 #26666] ERROR -- puppet XXX::puppet::_opt_puppetlabs_puppet_cache_state_last_run_summary_yaml: Permission denied @ rb_sysopen - /opt/puppetlabs/puppet/cache/state/last_run_summary.yaml
 /usr/lib/ruby/2.1.0/psych.rb:464:in `initialize'
 /usr/lib/ruby/2.1.0/psych.rb:464:in `open'
 /usr/lib/ruby/2.1.0/psych.rb:464:in `load_file'
 /var/lib/gems/2.1.0/gems/bipbip-0.7.11/lib/bipbip/plugin/puppet.rb:58:in `last_run_summary'
 /var/lib/gems/2.1.0/gems/bipbip-0.7.11/lib/bipbip/plugin/puppet.rb:22:in `monitor'
 /var/lib/gems/2.1.0/gems/bipbip-0.7.11/lib/bipbip/plugin.rb:80:in `run_measurement'
 /var/lib/gems/2.1.0/gems/bipbip-0.7.11/lib/bipbip/plugin.rb:39:in `block (2 levels) in run'
 /usr/lib/ruby/2.1.0/timeout.rb:91:in `block in timeout'
 /usr/lib/ruby/2.1.0/timeout.rb:101:in `call'
 /usr/lib/ruby/2.1.0/timeout.rb:101:in `timeout'
 /var/lib/gems/2.1.0/gems/bipbip-0.7.11/lib/bipbip/plugin.rb:38:in `block in run'
 /var/lib/gems/2.1.0/gems/bipbip-0.7.11/lib/bipbip/plugin.rb:36:in `loop'
 /var/lib/gems/2.1.0/gems/bipbip-0.7.11/lib/bipbip/plugin.rb:36:in `run'
 /var/lib/gems/2.1.0/gems/bipbip-0.7.11/lib/bipbip/agent.rb:65:in `block in start_plugin'
````


`debian/postinst` in the newest `puppet-agent-1.9.4` deb:
```
[..]
# Set up any specific permissions needed...
  chmod '0750' '/opt/puppetlabs/puppet/cache'
[..]
```

We need to manage this directory ourselves in order for bipbip to be able to access `last_run_summary.yaml`