### PR TITLE
SYS-241 Increase nofile limit for upsource

### DIFF
--- a/modules/jetbrains/manifests/upsource.pp
+++ b/modules/jetbrains/manifests/upsource.pp
@@ -19,7 +19,7 @@ class jetbrains::upsource (
     config        => file("${module_name}/upsource.config"),
     hub_url       => $hub_url,
     limit_memlock => 'unlimited',
-    limit_nofile  => 65536,
+    limit_nofile  => 500000,
     limit_nproc   => 32768,
     limit_as      => 'unlimited',
   }


### PR DESCRIPTION
It seems that Upsource threads are not sharing file handles.
Therefore the nofile limit for the whole *service* needs to be quite high!