### PR TITLE
FB-1490 Use git:// scheme for Github Puppetfile-sources

### DIFF
--- a/modules/apt/Puppetfile
+++ b/modules/apt/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/ucf',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ucf'

--- a/modules/augeas/Puppetfile
+++ b/modules/augeas/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/autoprefixer/Puppetfile
+++ b/modules/autoprefixer/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'

--- a/modules/autossh/Puppetfile
+++ b/modules/autossh/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/daemon',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/daemon'
 
 mod 'cargomedia/apt',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/apt'

--- a/modules/awscli/Puppetfile
+++ b/modules/awscli/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/python',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/python'

--- a/modules/backup/Puppetfile
+++ b/modules/backup/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/rdiff_backup',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/rdiff_backup'
 
 mod 'cargomedia/ssh',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ssh'

--- a/modules/bipbip/Puppetfile
+++ b/modules/bipbip/Puppetfile
@@ -1,15 +1,15 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/build',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/build'
 
 mod 'cargomedia/cgi_fcgi',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/cgi_fcgi'
 
 mod 'cargomedia/ruby',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ruby'

--- a/modules/bower/Puppetfile
+++ b/modules/bower/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'

--- a/modules/browserify/Puppetfile
+++ b/modules/browserify/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'

--- a/modules/build/Puppetfile
+++ b/modules/build/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/ca_certificates/Puppetfile
+++ b/modules/ca_certificates/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/capistrano/Puppetfile
+++ b/modules/capistrano/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/ruby',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ruby'

--- a/modules/cgi_fcgi/Puppetfile
+++ b/modules/cgi_fcgi/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/cm/Puppetfile
+++ b/modules/cm/Puppetfile
@@ -2,81 +2,81 @@ mod 'puppetlabs/stdlib',
   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 mod 'cargomedia/composer',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/composer'
 
 mod 'cargomedia/php5',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/php5'
 
 mod 'cargomedia/phpunit',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/phpunit'
 
 mod 'cargomedia/uglify',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/uglify'
 
 mod 'cargomedia/browserify',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/browserify'
 
 mod 'cargomedia/autoprefixer',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/autoprefixer'
 
 mod 'cargomedia/foreman',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/foreman'
 
 mod 'cargomedia/foreman_systemd',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/foreman_systemd'
 
 mod 'cargomedia/mysql',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/mysql'
 
 mod 'cargomedia/redis',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/redis'
 
 mod 'cargomedia/memcached',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/memcached'
 
 mod 'cargomedia/elasticsearch',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/elasticsearch'
 
 mod 'cargomedia/gearman',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/gearman'
 
 mod 'cargomedia/socket_redis',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/socket_redis'
 
 mod 'cargomedia/nginx',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nginx'
 
 mod 'cargomedia/bipbip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/bipbip'
 
 mod 'cargomedia/mongodb',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/mongodb'
 
 mod 'cargomedia/ufw',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ufw'
 
 mod 'cargomedia/phantomjs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/phantomjs'
 
 mod 'cargomedia/systemd',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/systemd'

--- a/modules/cm_bundler/Puppetfile
+++ b/modules/cm_bundler/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'

--- a/modules/composer/Puppetfile
+++ b/modules/composer/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/php5',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/php5'

--- a/modules/copperegg_revealcloud/Puppetfile
+++ b/modules/copperegg_revealcloud/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/daemon',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/daemon'

--- a/modules/cron/Puppetfile
+++ b/modules/cron/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'cargomedia/daemon',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/daemon'

--- a/modules/daemon/Puppetfile
+++ b/modules/daemon/Puppetfile
@@ -2,9 +2,9 @@ mod 'puppetlabs/stdlib',
   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 mod 'cargomedia/systemd',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/systemd'
 
 mod 'cargomedia/sudo',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/sudo'

--- a/modules/docker/Puppetfile
+++ b/modules/docker/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'

--- a/modules/dyndns/Puppetfile
+++ b/modules/dyndns/Puppetfile
@@ -2,9 +2,9 @@ mod 'puppetlabs/stdlib',
   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/cron',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/cron'

--- a/modules/earlyoom/Puppetfile
+++ b/modules/earlyoom/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/helper',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/helper'
 
 mod 'cargomedia/git',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/git'
 
 mod 'cargomedia/daemon',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/daemon'

--- a/modules/elasticsearch/Puppetfile
+++ b/modules/elasticsearch/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/java',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/java'
 
 mod 'cargomedia/helper',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/helper'

--- a/modules/fluentd/Puppetfile
+++ b/modules/fluentd/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/ruby',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/ruby'
 
 mod 'cargomedia/daemon',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/daemon'
 
 mod 'cargomedia/logrotate',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/logrotate'

--- a/modules/foreman/Puppetfile
+++ b/modules/foreman/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/ruby',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ruby'

--- a/modules/foreman_systemd/Puppetfile
+++ b/modules/foreman_systemd/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/foreman',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/foreman'

--- a/modules/fs/Puppetfile
+++ b/modules/fs/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/apt',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/apt'
 
 mod 'cargomedia/systemd',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/systemd'

--- a/modules/gearman/Puppetfile
+++ b/modules/gearman/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/bipbip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/bipbip'
 
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'

--- a/modules/git/Puppetfile
+++ b/modules/git/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/github/Puppetfile
+++ b/modules/github/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/ssh',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ssh'

--- a/modules/goreplay/Puppetfile
+++ b/modules/goreplay/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/helper',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/helper'

--- a/modules/java/Puppetfile
+++ b/modules/java/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/jenkins/Puppetfile
+++ b/modules/jenkins/Puppetfile
@@ -1,19 +1,19 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/ntp',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ntp'
 
 mod 'cargomedia/ssh',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ssh'
 
 mod 'cargomedia/unzip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/unzip'
 
 mod 'cargomedia/ufw',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/ufw'

--- a/modules/jetbrains/Puppetfile
+++ b/modules/jetbrains/Puppetfile
@@ -1,26 +1,26 @@
 mod 'cargomedia/nginx',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nginx'
 
 mod 'cargomedia/daemon',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/daemon'
 
 mod 'cargomedia/helper',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/helper'
 
 mod 'puppetlabs/stdlib',
     :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 mod 'cargomedia/ufw',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/ufw'
 
 mod 'cargomedia/unzip',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/unzip'
 
 mod 'cargomedia/apt',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/apt'

--- a/modules/less/Puppetfile
+++ b/modules/less/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'

--- a/modules/librarian_puppet/Puppetfile
+++ b/modules/librarian_puppet/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/ruby',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ruby'

--- a/modules/loggly_github/Puppetfile
+++ b/modules/loggly_github/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'
 
 mod 'cargomedia/daemon',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/daemon'
 
 mod 'cargomedia/nginx',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nginx'

--- a/modules/logrotate/Puppetfile
+++ b/modules/logrotate/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/memcached/Puppetfile
+++ b/modules/memcached/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/bipbip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/bipbip'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'cargomedia/daemon',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/daemon'

--- a/modules/mms/Puppetfile
+++ b/modules/mms/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/helper',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/helper'
 
 mod 'cargomedia/daemon',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/daemon'

--- a/modules/mongodb/Puppetfile
+++ b/modules/mongodb/Puppetfile
@@ -2,21 +2,21 @@ mod 'puppetlabs/stdlib',
   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/ntp',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ntp'
 
 mod 'cargomedia/bipbip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/bipbip'
 
 mod 'cargomedia/logrotate',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/logrotate'
 
 mod 'cargomedia/daemon',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/daemon'

--- a/modules/mysql/Puppetfile
+++ b/modules/mysql/Puppetfile
@@ -1,27 +1,27 @@
 mod 'cargomedia/sysctl',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/sysctl'
 
 mod 'cargomedia/bipbip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/bipbip'
 
 mod 'cargomedia/database',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/database'
 
 mod 'cargomedia/logrotate',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/logrotate'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'cargomedia/daemon',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/daemon'
 
 mod 'cargomedia/fluentd',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/fluentd'

--- a/modules/mysql_proxy/Puppetfile
+++ b/modules/mysql_proxy/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/daemon',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/daemon'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/mysqltuner/Puppetfile
+++ b/modules/mysqltuner/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/needrestart/Puppetfile
+++ b/modules/needrestart/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/network/Puppetfile
+++ b/modules/network/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/augeas',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/augeas'
 
 mod 'cargomedia/sysctl',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/sysctl'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/newrelic/Puppetfile
+++ b/modules/newrelic/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/daemon',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/daemon'
 
 mod 'cargomedia/apt',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/apt'

--- a/modules/nginx/Puppetfile
+++ b/modules/nginx/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/bipbip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/bipbip'
 
 mod 'cargomedia/ufw',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/ufw'

--- a/modules/nodejs/Puppetfile
+++ b/modules/nodejs/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'

--- a/modules/ntp/Puppetfile
+++ b/modules/ntp/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/openssl/Puppetfile
+++ b/modules/openssl/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/phantomjs/Puppetfile
+++ b/modules/phantomjs/Puppetfile
@@ -2,9 +2,9 @@ mod 'puppetlabs/stdlib',
   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'

--- a/modules/php5/Puppetfile
+++ b/modules/php5/Puppetfile
@@ -1,31 +1,31 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/build',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/build'
 
 mod 'cargomedia/helper',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/helper'
 
 mod 'cargomedia/gearman',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/gearman'
 
 mod 'cargomedia/bipbip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/bipbip'
 
 mod 'cargomedia/git',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/git'
 
 mod 'cargomedia/openssl',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/openssl'
 
 mod 'cargomedia/fluentd',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/fluentd'

--- a/modules/phpunit/Puppetfile
+++ b/modules/phpunit/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/php5',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/php5'

--- a/modules/polipo/Puppetfile
+++ b/modules/polipo/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/postfix/Puppetfile
+++ b/modules/postfix/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/ca_certificates',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ca_certificates'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/postgresql/Puppetfile
+++ b/modules/postgresql/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/pulsar/Puppetfile
+++ b/modules/pulsar/Puppetfile
@@ -1,15 +1,15 @@
 mod 'cargomedia/capistrano',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/capistrano'
 
 mod 'cargomedia/git',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/git'
 
 mod 'cargomedia/ruby',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ruby'
 
 mod 'cargomedia/env',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/env'

--- a/modules/pulsar_rest_api/Puppetfile
+++ b/modules/pulsar_rest_api/Puppetfile
@@ -1,27 +1,27 @@
 mod 'cargomedia/pulsar',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/pulsar'
 
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'
 
 mod 'cargomedia/mongodb',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/mongodb'
 
 mod 'cargomedia/logrotate',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/logrotate'
 
 mod 'cargomedia/helper',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/helper'
 
 mod 'cargomedia/bower',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/bower'
 
 mod 'cargomedia/daemon',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/daemon'

--- a/modules/puppet/Puppetfile
+++ b/modules/puppet/Puppetfile
@@ -2,37 +2,37 @@ mod 'puppetlabs/stdlib',
   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 mod 'cargomedia/ssh',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ssh'
 
 mod 'cargomedia/helper',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/helper'
 
 mod 'cargomedia/git',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/git'
 
 mod 'cargomedia/ruby',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ruby'
 
 mod 'cargomedia/librarian_puppet',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/librarian_puppet'
 
 mod 'cargomedia/rsync',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/rsync'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'cargomedia/daemon',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/daemon'
 
 mod 'cargomedia/bipbip',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/bipbip'

--- a/modules/puppetserver/Puppetfile
+++ b/modules/puppetserver/Puppetfile
@@ -2,25 +2,25 @@ mod 'puppetlabs/stdlib',
   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 mod 'cargomedia/ssh',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/ssh'
 
 mod 'cargomedia/git',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/git'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'cargomedia/puppet',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/puppet'
 
 mod 'cargomedia/postgresql',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/postgresql'
 
 mod 'cargomedia/ufw',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/ufw'

--- a/modules/python/Puppetfile
+++ b/modules/python/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/raid/Puppetfile
+++ b/modules/raid/Puppetfile
@@ -2,17 +2,17 @@ mod 'puppetlabs/stdlib',
   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/helper',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/helper'
 
 mod 'cargomedia/python',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/python'
 
 mod 'cargomedia/unzip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/unzip'

--- a/modules/rdiff_backup/Puppetfile
+++ b/modules/rdiff_backup/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/redis/Puppetfile
+++ b/modules/redis/Puppetfile
@@ -1,12 +1,12 @@
 mod 'cargomedia/bipbip',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/bipbip'
 
 mod 'cargomedia/sysctl',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/sysctl'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 

--- a/modules/revive/Puppetfile
+++ b/modules/revive/Puppetfile
@@ -1,19 +1,19 @@
 mod 'cargomedia/php5',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/php5'
 
 mod 'cargomedia/nginx',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nginx'
 
 mod 'cargomedia/mysql',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/mysql'
 
 mod 'cargomedia/rsync',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/rsync'
 
 mod 'cargomedia/helper',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/helper'

--- a/modules/rsync/Puppetfile
+++ b/modules/rsync/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/rsyslog/Puppetfile
+++ b/modules/rsyslog/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'cargomedia/fluentd',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/fluentd'

--- a/modules/ruby/Puppetfile
+++ b/modules/ruby/Puppetfile
@@ -1,7 +1,7 @@
 mod 'cargomedia/build',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/build'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/satis/Puppetfile
+++ b/modules/satis/Puppetfile
@@ -1,15 +1,15 @@
 mod 'cargomedia/composer',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/composer'
 
 mod 'cargomedia/git',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/git'
 
 mod 'cargomedia/nginx',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nginx'
 
 mod 'cargomedia/ufw',
-    :git => 'git@github.com:cargomedia/puppet-packages.git',
+    :git => 'git://github.com/cargomedia/puppet-packages.git',
     :path => 'modules/ufw'

--- a/modules/socket_redis/Puppetfile
+++ b/modules/socket_redis/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'
 
 mod 'cargomedia/daemon',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/daemon'
 
 mod 'cargomedia/redis',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/redis'

--- a/modules/squid_deb_proxy/Puppetfile
+++ b/modules/squid_deb_proxy/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'

--- a/modules/ssh/Puppetfile
+++ b/modules/ssh/Puppetfile
@@ -1,13 +1,13 @@
 mod 'cargomedia/helper',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/helper'
 
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'cargomedia/ufw',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/ufw'
 
 mod 'puppetlabs/stdlib',

--- a/modules/sudo/Puppetfile
+++ b/modules/sudo/Puppetfile
@@ -1,5 +1,5 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'puppetlabs/stdlib',

--- a/modules/systemd/Puppetfile
+++ b/modules/systemd/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'cargomedia/sysctl',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/sysctl'
 
 mod 'cargomedia/bipbip',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/bipbip'

--- a/modules/ucf/Puppetfile
+++ b/modules/ucf/Puppetfile
@@ -1,4 +1,4 @@
 # Cyclic dependencies not supported
 #mod 'cargomedia/apt',
-#   :git => 'git@github.com:cargomedia/puppet-packages.git',
+#   :git => 'git://github.com/cargomedia/puppet-packages.git',
 #   :path => 'modules/apt'

--- a/modules/ufw/Puppetfile
+++ b/modules/ufw/Puppetfile
@@ -1,5 +1,5 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'
 
 mod 'puppetlabs/stdlib',

--- a/modules/uglify/Puppetfile
+++ b/modules/uglify/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/nodejs',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/nodejs'

--- a/modules/unzip/Puppetfile
+++ b/modules/unzip/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/vagrant/Puppetfile
+++ b/modules/vagrant/Puppetfile
@@ -1,11 +1,11 @@
 mod 'cargomedia/helper',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/helper'
 
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'
 
 mod 'cargomedia/build',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/build'

--- a/modules/vim/Puppetfile
+++ b/modules/vim/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-   :git => 'git@github.com:cargomedia/puppet-packages.git',
+   :git => 'git://github.com/cargomedia/puppet-packages.git',
    :path => 'modules/apt'

--- a/modules/virtualbox/Puppetfile
+++ b/modules/virtualbox/Puppetfile
@@ -1,3 +1,3 @@
 mod 'cargomedia/apt',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :git => 'git://github.com/cargomedia/puppet-packages.git',
   :path => 'modules/apt'


### PR DESCRIPTION
This way librarian-puppet uses HTTP to connect to Github, so we don't need an SSH key.