### PR TITLE
Upgrade elasticsearch from 1.4 to 2.4

### DIFF
--- a/modules/elasticsearch/manifests/init.pp
+++ b/modules/elasticsearch/manifests/init.pp
@@ -38,7 +38,8 @@ class elasticsearch (
 
   daemon { 'elasticsearch':
     binary  => '/usr/share/elasticsearch/bin/elasticsearch',
-    args => "-Des.default.config=${config_file} -Des.default.path.home=/usr/share/elasticsearch -Des.default.path.logs=/var/log/elasticsearch -Des.default.path.data=/var/lib/elasticsearch -Des.default.path.work=/tmp/elasticsearch -Des.default.path.conf=${config_dir}",
+    args => "-Des.default.path.home=/usr/share/elasticsearch -Des.default.path.logs=/var/log/elasticsearch -Des.default.path.data=/var/lib/elasticsearch -Des.default.path.work=/tmp/elasticsearch -Des.default.path.conf=${config_dir}",
+    user => 'elasticsearch',
     env     => {
       'ES_HEAP_SIZE' => $heap_size,
       'ES_USER' => 'elasticsearch',

--- a/modules/elasticsearch/manifests/package.pp
+++ b/modules/elasticsearch/manifests/package.pp
@@ -1,5 +1,5 @@
 class elasticsearch::package (
-  $repository_version = '1.4',
+  $repository_version = '2.x',
 ){
 
   apt::source { 'elasticsearch':

--- a/modules/elasticsearch/spec/heap-size-undef/spec.rb
+++ b/modules/elasticsearch/spec/heap-size-undef/spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe 'elasticsearch heap-size-undef' do
 
   describe command('ps aux | grep elasticsearch') do
-    its(:stdout) { should match 'java -Xms1g -Xmx1g -Xss256k' }
+    its(:stdout) { should match 'java -Xms1g -Xmx1g' }
   end
 end

--- a/modules/elasticsearch/spec/init/spec.rb
+++ b/modules/elasticsearch/spec/init/spec.rb
@@ -21,8 +21,8 @@ describe 'elasticsearch' do
   end
 
   describe command('curl localhost:9200/_nodes/_local') do
-    its(:stdout) { should match /\{"cluster_name":"foo",/}
-    its(:stdout) { should match /,"node":\{"local":"true"\},/}
-    its(:stdout) { should match /"publish_address":"inet\[localhost\/127\.0\.0\.1:9200\]/}
+    its(:stdout) { should match '{"cluster_name":"foo"'}
+    its(:stdout) { should match '"node":{"local":"true"}'}
+    its(:stdout) { should match '"publish_address":"127.0.0.1:9200"'}
   end
 end


### PR DESCRIPTION
For https://github.com/cargomedia/sk/issues/5239

Stop old version:
```
sudo systemctl stop elasticsearch
```

Create a backup and change ownership of "index" directory:
```
sudo cp -R /var/lib/elasticsearch /var/lib/elasticsearch.bak
sudo chown -R elasticsearch: /var/lib/elasticsearch
```

Upgrade with puppet:
```
puppet agent -t
```

Check status:
```
curl -X GET http://localhost:9200/_cat/health
curl -X GET http://localhost:9200/_cat/recovery
curl -X GET http://localhost:9200/_cat/nodes
```

