### PR TITLE
Upgrade elasticsearch from 2.4 to 5.6

### DIFF
--- a/modules/elasticsearch/manifests/init.pp
+++ b/modules/elasticsearch/manifests/init.pp
@@ -1,6 +1,6 @@
 class elasticsearch (
   $publish_host = undef,
-  $heap_size = '1g',
+  $heap_size    = '1g',
   $cluster_name = undef
 ) {
 
@@ -27,6 +27,15 @@ class elasticsearch (
     notify  => Service['elasticsearch'],
   }
 
+  file { "${config_dir}/jvm.options":
+    ensure  => file,
+    content => template("${module_name}/jvm.options.erb"),
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+    notify  => Service['elasticsearch'],
+  }
+
   file { '/etc/default/elasticsearch':
     ensure  => file,
     content => template("${module_name}/default"),
@@ -37,23 +46,23 @@ class elasticsearch (
   }
 
   daemon { 'elasticsearch':
-    binary  => '/usr/share/elasticsearch/bin/elasticsearch',
-    args => "-Des.default.path.home=/usr/share/elasticsearch -Des.default.path.logs=/var/log/elasticsearch -Des.default.path.data=/var/lib/elasticsearch -Des.default.path.work=/tmp/elasticsearch -Des.default.path.conf=${config_dir}",
-    user => 'elasticsearch',
-    env     => {
-      'ES_HEAP_SIZE' => $heap_size,
-      'ES_USER' => 'elasticsearch',
-      'ES_GROUP' => 'elasticsearch',
+    binary       => '/usr/share/elasticsearch/bin/elasticsearch',
+    args         => "-Edefault.path.logs=/var/log/elasticsearch -Edefault.path.data=/var/lib/elasticsearch -Edefault.path.conf=${config_dir}",
+    user         => 'elasticsearch',
+    env          => {
+      'ES_USER'       => 'elasticsearch',
+      'ES_GROUP'      => 'elasticsearch',
       'MAX_MAP_COUNT' => '262144',
     },
-    require => File[$config_file],
+    require      => File[$config_file],
+    limit_nofile => 100000,
   }
 
   @bipbip::entry { 'elasticsearch':
     plugin  => 'elasticsearch',
     options => {
       'hostname' => 'localhost',
-      'port' => '9200',
+      'port'     => '9200',
     },
   }
 }

--- a/modules/elasticsearch/manifests/package.pp
+++ b/modules/elasticsearch/manifests/package.pp
@@ -1,10 +1,10 @@
 class elasticsearch::package (
-  $repository_version = '2.x',
+  $repository_version = '5.x',
 ){
 
   apt::source { 'elasticsearch':
     entries => [
-      "deb http://packages.elastic.co/elasticsearch/${repository_version}/debian stable main",
+      "deb https://artifacts.elastic.co/packages/${repository_version}/apt stable main",
     ],
     keys    => {
       elasticsearch => {

--- a/modules/elasticsearch/spec/heap-size-undef/spec.rb
+++ b/modules/elasticsearch/spec/heap-size-undef/spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 describe 'elasticsearch heap-size-undef' do
 
+  # Wait for elasticsearch to start up
+  describe command('timeout --signal=9 30 bash -c "while ! (curl -s http://localhost:9200/); do sleep 0.5; done"') do
+    its(:exit_status) { should eq 0 }
+  end
+
   describe command('ps aux | grep elasticsearch') do
     its(:stdout) { should match 'java -Xms1g -Xmx1g' }
   end

--- a/modules/elasticsearch/spec/init/spec.rb
+++ b/modules/elasticsearch/spec/init/spec.rb
@@ -21,8 +21,8 @@ describe 'elasticsearch' do
   end
 
   describe command('curl localhost:9200/_nodes/_local') do
-    its(:stdout) { should match '{"cluster_name":"foo"'}
-    its(:stdout) { should match '"node":{"local":"true"}'}
+    its(:stdout) { should match '"cluster_name":"foo"'}
+    its(:stdout) { should match '"transport":{"type":"local"}'}
     its(:stdout) { should match '"publish_address":"127.0.0.1:9200"'}
   end
 end

--- a/modules/elasticsearch/spec/init/spec.rb
+++ b/modules/elasticsearch/spec/init/spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 describe 'elasticsearch' do
 
+  # Wait for elasticsearch to start up
+  describe command('timeout --signal=9 30 bash -c "while ! (curl -s http://localhost:9200/); do sleep 0.5; done"') do
+    its(:exit_status) { should eq 0 }
+  end
+
   describe package('elasticsearch') do
     it { should be_installed }
   end

--- a/modules/elasticsearch/templates/elasticsearch.yml
+++ b/modules/elasticsearch/templates/elasticsearch.yml
@@ -1,3 +1,3 @@
 <%= 'cluster.name: ' + @cluster_name if @cluster_name %>
 <%= 'network.publish_host: ' + @publish_host if @publish_host %>
-node.local: true
+transport.type: local

--- a/modules/elasticsearch/templates/jvm.options.erb
+++ b/modules/elasticsearch/templates/jvm.options.erb
@@ -1,0 +1,111 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms<%= @heap_size %>
+-Xmx<%= @heap_size %>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM (remove on 32-bit client JVMs)
+-server
+
+# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# By default, the GC log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true


### PR DESCRIPTION
For https://github.com/cargomedia/sk/issues/5239

Stop old version:
```
sudo systemctl stop elasticsearch
```

Create a backup and change ownership of "index" directory:
```
sudo cp -R /var/lib/elasticsearch /var/lib/elasticsearch.bak-2.4
sudo chown -R elasticsearch: /var/lib/elasticsearch
```

Upgrade:
```
sudo puppet agent -t
sudo apt-get install -o Dpkg::Options::="--force-confold" elasticsearch
```

Check status:
```
curl -X GET http://localhost:9200/_cat/health
curl -X GET http://localhost:9200/_cat/indices
```
And:
```
curl -X GET http://localhost:9200/_cat/recovery
curl -X GET http://localhost:9200/_cat/nodes
curl -X GET http://localhost:9200/_cat/shards
```


  
  